### PR TITLE
Added the EncryptedAttribute element, which uses the xmlenc gem. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source "http://rubygems.org"
 # development dependencies will be added by default to the :development group.
 gemspec
 
+gem "xmlenc", github: "digidentity/xmlenc", ref: "2e9d8adabca954e70afe7344da951d3af1d8a7ab"
+
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/digidentity/xmlenc.git
+  revision: 2e9d8adabca954e70afe7344da951d3af1d8a7ab
+  ref: 2e9d8adabca954e70afe7344da951d3af1d8a7ab
+  specs:
+    xmlenc (0.0.1)
+      activemodel (>= 3.0.0)
+      activesupport (>= 3.0.0)
+      nokogiri (~> 1.6)
+
 PATH
   remote: .
   specs:
@@ -48,8 +58,9 @@ GEM
       guard (>= 1.1)
       rspec (~> 2.11)
     hike (1.2.1)
-    httpi (2.0.2)
+    httpi (2.1.0)
       rack
+      rubyntlm (~> 0.3.2)
     i18n (0.6.1)
     journey (1.0.4)
     jquery-rails (2.2.1)
@@ -101,6 +112,7 @@ GEM
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
       rspec-mocks (~> 2.13.0)
+    rubyntlm (0.3.4)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -115,7 +127,7 @@ GEM
     terminal-table (1.4.5)
     thor (0.17.0)
     tilt (1.3.6)
-    xmldsig (0.2.1)
+    xmldsig (0.2.2)
       nokogiri
 
 PLATFORMS
@@ -129,3 +141,4 @@ DEPENDENCIES
   rspec-rails
   simplecov
   sqlite3
+  xmlenc!

--- a/lib/saml.rb
+++ b/lib/saml.rb
@@ -4,6 +4,7 @@ require 'saml/base'
 require 'saml/xml_helpers'
 require 'saml/encoding'
 require 'saml/util'
+require 'xmlenc'
 require 'xmldsig'
 require 'httpi'
 
@@ -113,6 +114,7 @@ module Saml
     require 'saml/elements/sp_sso_descriptor'
     require 'saml/elements/entity_descriptor'
     require 'saml/elements/entities_descriptor'
+    require 'saml/elements/encrypted_attribute'
   end
 
   require 'saml/assertion'

--- a/lib/saml/elements/encrypted_attribute.rb
+++ b/lib/saml/elements/encrypted_attribute.rb
@@ -1,0 +1,18 @@
+module Saml
+  module Elements
+    class EncryptedAttribute
+      include Saml::Base
+
+      tag "EncryptedAttribute"
+
+      register_namespace "saml", Saml::SAML_NAMESPACE
+      namespace "saml"
+
+      element :encrypted_data, Xmlenc::Builder::EncryptedData
+
+      has_many :encrypted_keys, Xmlenc::Builder::EncryptedKey
+
+      validates :encrypted_data, presence: true
+    end
+  end
+end

--- a/spec/fixtures/encrypted_attribute.xml
+++ b/spec/fixtures/encrypted_attribute.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<saml:EncryptedAttribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+  <xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Type="http://www.w3.org/2001/04/xmlenc#Element" Id="_F39625AF68B4FC078CC7582D28D05D9C">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+    <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <xenc:EncryptedKey>
+        <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+        <ds:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+          <ds:KeyName>62355fbd1f624503c5c9677402ecca00ef1f6277</ds:KeyName>
+        </ds:KeyInfo>
+        <xenc:CipherData>
+          <xenc:CipherValue>K0mBLxfLziKVUKEAOYe7D6uVSCPy8vyWVh3RecnPES+8QkAhOuRSuE/LQpFr0huI/iCEy9pde1QgjYDLtjHcujKi2xGqW6jkXW/EuKomqWPPA2xYs1fpB1su4aXUOQB6OJ70/oDcOsy834ghFaBWilE8fqyDBUBvW+2IvaMUZabwN/s9mVkWzM3r30tlkhLK7iOrbGAldIHwFU5z7PPR6RO3Y3fIxjHU40OnLsJc3xIqdLH3fXpC0kgi5UspLdq14e5OoXjLoPG3BO3zwOAIJ8XNBWY5uQof6KrKbcvtZSY0fMvPYhYfNjtRFy8y49ovL9fwjCRTDlT5+aHqsCTBrw==</xenc:CipherValue>
+        </xenc:CipherData>
+      </xenc:EncryptedKey>
+    </ds:KeyInfo>
+    <xenc:CipherData>
+      <xenc:CipherValue>ZzCu6axGgAYZHVf77NX8apZKB/GJDeuV6bFByBS0AIgiXkvDUAmLCpabTAWBM+yz19olA6rryuOfr82ev2bzPNURvm4SYxahvuL4Pibn5wJky0Bl54VqmcU+Aqj0dAvOgqG1y3X4wO9n9bRsTv6921m0eqRAFph8kK8L9hirK1BxYBYj2RyFCoFDPxVZ5wyra3q4qmE4/ELQpFP6mfU8LXb0uoWJUjGUelS2Aa7bZis8zEpwov4CwtlNjltQih4mv7ttCAfYqcQIFzBTB+DAa0+XggxCLcdB3+mQiRcECBfwHHJ7gRmnuBEgeWT3CGKa3Nb7GMXOfuxFKF5pIehWgo3kdNQLalor8RVW6I8P/I8fQ33Fe+NsHVnJ3zwSA//a</xenc:CipherValue>
+    </xenc:CipherData>
+  </xenc:EncryptedData>
+</saml:EncryptedAttribute>

--- a/spec/lib/saml/elements/encrypted_attribute_spec.rb
+++ b/spec/lib/saml/elements/encrypted_attribute_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe Saml::Elements::EncryptedAttribute do
+
+  let(:xml) { File.read File.join("spec", "fixtures", "encrypted_attribute.xml") }
+  subject   { described_class.parse(xml, single: true) }
+
+  describe "Required fields" do
+    [:encrypted_data].each do |field|
+      it "should have the #{field} field" do
+        subject.should respond_to(field)
+      end
+
+      it "should check the presence of #{field}" do
+        subject.send("#{field}=", nil)
+        subject.should_not be_valid
+      end
+    end
+  end
+
+  describe "Optional fields" do
+    [:encrypted_keys].each do |field|
+      it "should have the #{field} field" do
+        subject.should respond_to(field)
+      end
+
+      it "should allow #{field} to blank" do
+        subject.send("#{field}=", nil)
+        subject.should be_valid
+      end
+    end
+  end
+
+  describe "#parse" do
+    it "should create the EncryptedAttribute" do
+      expect(subject).to be_a Saml::Elements::EncryptedAttribute
+    end
+
+    it "should parse the encrypted data" do
+      expect(subject.encrypted_data).to be_a Xmlenc::Builder::EncryptedData
+    end
+
+    it "should parse the encrypted key" do
+      expect(subject.encrypted_keys.first).to be_a Xmlenc::Builder::EncryptedKey
+    end
+  end
+end


### PR DESCRIPTION
I've temporarily added it to the Gemfile itself (instead of the gemspec), since the Rubygems version doesn't included the required code yet. Once that has been released, we can remove the reference in the Gemfile and add it as a dependency in the gemspec.
