### PR TITLE
Use a proc to determine the current time in the factories

### DIFF
--- a/spec/factories/all.rb
+++ b/spec/factories/all.rb
@@ -37,7 +37,7 @@ FactoryGirl.define do
   factory :request_abstract_type_dummy, :class => RequestAbstractTypeDummy do
     _id "_#{Time.now.to_i}"
     version "2.0"
-    issue_instant Time.now
+    issue_instant { Time.now }
     issuer "http://sp.example.com"
   end
 
@@ -52,7 +52,7 @@ FactoryGirl.define do
   factory :status_response_type_dummy, :class => StatusResponseTypeDummy do
     _id "_#{Time.now.to_i}"
     version "2.0"
-    issue_instant Time.now
+    issue_instant { Time.now }
     in_response_to "_#{Time.now.to_i}"
     status FactoryGirl.build(:status)
   end
@@ -70,7 +70,7 @@ FactoryGirl.define do
   factory :assertion, :class => Saml::Assertion do
     _id "_#{Time.now.to_i}"
     version "2.0"
-    issue_instant Time.now
+    issue_instant { Time.now }
     issuer "valid_issuer"
   end
 
@@ -99,7 +99,7 @@ FactoryGirl.define do
   end
 
   factory :authn_statement, :class => Saml::Elements::AuthnStatement do
-    authn_instant Time.now
+    authn_instant { Time.now }
     authn_context FactoryGirl.build(:authn_context)
   end
 


### PR DESCRIPTION
If `Time.now` is set in a factory, the factory memorizes the set attribute throughout the testsuite. So if the time between initializing the factory and using the factory is lager than the `max_issue_instant_offset` set in the `Saml::Config` the created instance for that factory becomes invalid. Using a Proc for the `Time.now` in the factory sets the attribute every time it's called, instead of memorizing it. You can encounter this issue with the validation of the `issue_instant` from the class `Saml::Assertion`.
