### PR TITLE
Remove any whitespace character in the certificate

### DIFF
--- a/lib/saml/elements/key_descriptor/key_info/x509_data.rb
+++ b/lib/saml/elements/key_descriptor/key_info/x509_data.rb
@@ -19,7 +19,7 @@ module Saml
           def x509certificate=(cert)
             if cert.present?
               unless cert =~ /-----BEGIN CERTIFICATE-----/
-                cert = cert.gsub(/\n/, '')
+                cert = cert.gsub(/\s/, '')
                 cert = "-----BEGIN CERTIFICATE-----\n#{cert.gsub(/(.{1,64})/, "\\1\n")}-----END CERTIFICATE-----"
               end
               @x509certificate = OpenSSL::X509::Certificate.new(cert)

--- a/spec/fixtures/metadata_with_whitespace.xml
+++ b/spec/fixtures/metadata_with_whitespace.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" ID="_052c51476c9560a429e1171e8c9528b96b69fb57" entityID="https://sp.example.com">
+  <md:SPSSODescriptor AuthnRequestsSigned="true">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:KeyName>22cd8e9f32a7262d2f49f5ccc518ccfbf8441bb8</ds:KeyName>
+        <ds:X509Data>
+          <ds:X509Certificate>
+            MIICgjCCAeugAwIBAgIBADANBgkqhkiG9w0BAQUFADA6MQswCQYDVQQGEwJCRTENMAsGA1UECgwEVGVzdDENMAsGA1UECwwEVGVzdDENMAsGA1UEAwwEVGVzdDAeFw0xMzAxMTQxMzM5NTBaFw0xNDAxMTQxMzM5NTBaMDoxCzAJBgNVBAYTAkJFMQ0wCwYDVQQKDARUZXN0MQ0wCwYDVQQLDARUZXN0MQ0wCwYDVQQDDARUZXN0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDgJhsC/EH+FebE7OfgwWyQgSxX
+            iY4i5XMj/U+MJUsZ1O2jb70aMkb3hwXKGPWBV0fHHKkdeugchxKx/973fvrkgiYWiy3j6yUyBzSgWoCKcZGZEng5cgA9L/6roVkpnjNCYc49PQYa68+cLy419ooWSEYnTFlDpUiShviljEWT6wIDAQABo4GXMIGUMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFBJIbgZXUnf4On2C9KiGNrvcBXvvMGIGA1UdIwRbMFmAFBJIbgZXUnf4On2C9KiGNrvcBXvvoT6kPDA6MQswCQYDVQQGEwJCRTENMAsGA1UECgwEVGVzdDENMAsGA1UECwwEVGVzdDENMAsGA1UEAwwEVGVzdIIBADANBgkqhkiG9w0BAQUFAAOBgQDJcmmrA4y1K/TLMLA/zWf90snZubfCFC1iR3gBSKi5v49OxM4vkZSLo9gQfUJGwohPqld/PB6B1o1gpHEcbxWEgFnL+3irPcNLpcXPLNvbpzHjCOhVvRHIwIw+ZwlWir1yQKYcNXIPUFRqdRRsAwyOT8Qv3yGWNPYzNQ16qzPYJg==
+          </ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:KeyName>82cd8e9f32a7262d2f49f5ccc518ccfbf8441bb8</ds:KeyName>
+        <ds:X509Data>
+          <ds:X509Certificate>MIICgjCCAeugAwIBAgIBADANBgkqhkiG9w0BAQUFADA6MQswCQYDVQQGEwJCRTENMAsGA1UECgwEVGVzdDENMAsGA1UECwwEVGVzdDENMAsGA1UEAwwEVGVzdDAeFw0xMzAxMTQxMzM5NTBaFw0xNDAxMTQxMzM5NTBaMDoxCzAJBgNVBAYTAkJFMQ0wCwYDVQQKDARUZXN0MQ0wCwYDVQQLDARUZXN0MQ0wCwYDVQQDDARUZXN0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDgJhsC/EH+FebE
+            7OfgwWyQgSxXiY4i5XMj/U+MJUsZ1O2jb70aMkb3hwXKGPWBV0fHHKkdeugchxKx/973fvrkgiYWiy3j6yUyBzSgWoCKcZGZEng5cgA9L/6roVkpnjNCYc49PQYa68+cLy419ooWSEYnTFlDpUiShviljEWT6wIDAQABo4GXMIGUMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFBJIbgZXUnf4On2C9KiGNrvcBXvvMGIGA1UdIwRbMFmAFBJIbgZXUnf4On2C9KiGNrvcBXvvoT6kPDA6MQswCQYDVQQGEwJCRTENMAsGA1UECgwEVGVzdDENMAsGA1UECwwEVGVzdDENMAsGA1UEAwwEVGVzdIIBADANBgkqhkiG9w0BAQUFAAOBgQDJcmmrA4y1K/TLMLA/zWf90snZubfCFC1iR3gBSKi5v49OxM4vkZSLo9gQfUJGwohPqld/PB6B1o1gpHEcbxWEgFnL+3irPcNLpcXPLNvbpzHjCOhVvRHIwIw+ZwlWir1yQKYcNXIPUFRqdRRsAwyOT8Qv3yGWNPYzNQ16qzPYJg==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="encryption">
+      <ds:KeyInfo>
+        <ds:KeyName>22cd8e9f32a7262d2f49f5ccc518ccfbf8441bb8</ds:KeyName>
+        <ds:X509Data>
+          <ds:X509Certificate>MIICgjCCAeugAwIBAgIBADANBgkqhkiG9w0BAQUFADA6MQswCQYDVQQGEwJCRTENMAsGA1UECgwEVGVzdDENMAsGA1UECwwEVGVzdDENMAsGA1UEAwwEVGVzdDAeFw0xMzAxMTQxMzM5NTBaFw0xNDAxMTQxMzM5NTBaMDoxCzAJBgNVBAYTAkJFMQ0wCwYDVQQKDARUZXN0MQ0wCwYDVQQLDARUZXN0MQ0wCwYDVQQDDARUZXN0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDgJhsC/EH+FebE7OfgwWyQgSxXiY4i5XMj/U+MJUsZ1O2jb70aMkb3hwXKGPWBV0fHHKkdeugchxKx/973fvrkgiYWiy3j6yUyBzSgWoCKcZGZEng5cgA9L/6roVkpnjNCYc49PQYa68+cLy419ooWSEYnTFlDpUiShviljEWT6wIDAQABo4GXMIGUMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFBJIbgZXUnf4On2C9KiGNrvcBXvvMGIGA1UdIwRbMFmAFBJIbgZXUnf4On2C9KiGNrvcBXvvoT6kPDA6MQswCQYDVQQGEwJCRTENMAsGA1UECgwEVGVzdDENMAsGA1UECwwEVGVzdDENMAsGA1UEAwwEVGVzdIIBADANB
+            gkqhkiG9w0BAQUFAAOBgQDJcmmrA4y1K/TLMLA/zWf90snZubfCFC1iR3gBSKi5v49OxM4vkZSLo9gQfUJGwohPqld/PB6B1o1gpHEcbxWEgFnL+3irPcNLpcXPLNvbpzHjCOhVvRHIwIw+ZwlWir1yQKYcNXIPUFRqdRRsAwyOT8Qv3yGWNPYzNQ16qzPYJg==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp.example.com/sso/logout"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" index="0" Location="https://sp.example.com/sso/receive_artifact"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" index="1" Location="https://sp.example.com/sso/receive_artifact_default" isDefault="true"/>
+    <md:AttributeConsumingService index="0" isDefault="true">
+      <md:ServiceName>Service Name</md:ServiceName>
+      <md:ServiceDescription>Service Description</md:ServiceDescription>
+      <md:RequestedAttribute Name="urn:sample:AdditionalAttribute:BusinessName" isRequired="false"/>
+    </md:AttributeConsumingService>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/spec/lib/saml/elements/key_descriptor_spec.rb
+++ b/spec/lib/saml/elements/key_descriptor_spec.rb
@@ -4,10 +4,16 @@ describe Saml::Elements::KeyDescriptor do
   let(:key_descriptor) { FactoryGirl.build(:key_descriptor) }
 
   describe "certificate" do
+    let(:xml)     { File.read('spec/fixtures/metadata_with_whitespace.xml') }
+
     it "does not raise an error if the certificate is invalid" do
       expect {
         described_class.new(:certificate => "invalid")
       }.not_to raise_error
+    end
+
+    it "removes any whitespace character in the string" do
+      expect(described_class.parse(xml, single: true).certificate.to_s).to eql(key_descriptor.certificate.to_s)
     end
   end
 


### PR DESCRIPTION
When the certificate doesn't start with `-----BEGIN CERTIFICATE-----`, it gets created from the certificate string. To comply with the [RFC 5280](http://www.heise.de/netze/rfc/rfcs/rfc5280.shtml), any whitespace character in the certificate needs to be removed see: [RFC 4518](http://www.heise.de/netze/rfc/rfcs/rfc4518.shtml) and [RFC 4354](http://www.ietf.org/rfc/rfc3454.txt).
However the `\n` regex pattern only matches the newlines, not all whitespace character. Therefor use the `\s` regex pattern which does match all whitespace character (tabs, spaces, newlines ect.).
This also prevents the `nested asn1` error in `OpenSSL::X509::Certificate`.
