### PR TITLE
Add caching headers to the responses for the Rails SAML controllers

### DIFF
--- a/lib/saml/rails/controller_helper.rb
+++ b/lib/saml/rails/controller_helper.rb
@@ -1,8 +1,8 @@
 module Saml
   module Rails
     module ControllerHelper
-      def self.extended(base)
-        base.class_eval { include Saml::Rails::ControllerHelper }
+      def self.included(base)
+        base.extend self
         base.before_filter :set_response_headers
       end
 

--- a/spec/lib/saml/rails/controller_helper_spec.rb
+++ b/spec/lib/saml/rails/controller_helper_spec.rb
@@ -17,7 +17,7 @@ describe Saml::Rails::ControllerHelper do
   end
 
   class Controller < ApplicationController
-    extend Saml::Rails::ControllerHelper
+    include Saml::Rails::ControllerHelper
 
     def self.before_filter(&block)
       new.run_callback(&block)


### PR DESCRIPTION
According to the [SAML 2.0 Bindings](http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf) the cache headers (`Cache-Control` and `Pragma`) on the HTTP responses must at least contain the `no-cache, no-store`.
- Adds the cache headers on the HTTP responses for the Rails SAML controllers
- Changes the `extend` hook for the `include` hook on the `Rails::ControllerHelper`
