### PR TITLE
Fix the billion laughs DoS attack, for Entity expansion.

### DIFF
--- a/lib/saml.rb
+++ b/lib/saml.rb
@@ -19,6 +19,8 @@ module Saml
   SAML_VERSION       = '2.0'
 
   module Errors
+    class HackAttack < RuntimeError
+    end
     class SamlError < StandardError
     end
     class SignatureInvalid < SamlError
@@ -198,6 +200,12 @@ module Saml
   end
 
   def self.parse_message(message, type)
+    begin
+      Hash.from_xml(message)
+    rescue RuntimeError => e
+      raise Errors::HackAttack.new "based on error: #{e}"
+    end
+
     if %w(authn_request response logout_request logout_response artifact_resolve artifact_response).include?(type.to_s)
       klass = "Saml::#{type.to_s.camelize}".constantize
       klass.parse(message, single: true)

--- a/spec/lib/saml_spec.rb
+++ b/spec/lib/saml_spec.rb
@@ -82,7 +82,31 @@ describe Saml do
   end
 
   describe ".parse_message" do
-    let(:message) { "message" }
+    let(:message) { "<message></message>" }
+
+    context "with a billion laughs" do
+      xml = <<-XML
+        <?xml version="1.0"?>
+        <!DOCTYPE lolz [
+        <!ENTITY lol "lol">
+        <!ELEMENT lolz (#PCDATA)>
+        <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+        <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+        <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+        <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+        <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+        <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+        <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+        <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+        <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+        ]>
+        <lolz test="&lol4;">&lol4;</lolz>
+      XML
+
+      it "raises an Saml::Errors::HackAttack for entity expansion has grown too large" do
+        expect{ Saml.parse_message(xml, '') }.to raise_error Saml::Errors::HackAttack, "based on error: entity expansion has grown too large"
+      end
+    end
 
     context "with default types" do
       [:authn_request, :response, :logout_request, :logout_response, :artifact_resolve, :artifact_response].each do |type|


### PR DESCRIPTION
This was already fixed in the REXML library of Ruby, but not in the native libxml library that is used by Nokogiri. Therefore parse the message first with the REXML in the Ruby library, by using Hash.from_xml. This will raise an “entity expansion has grown too large” RuntimeError.
