### PR TITLE
Retrieve the AssertionConsumerService by index or if it isn't specified retrieve the default.

### DIFF
--- a/lib/saml/provider.rb
+++ b/lib/saml/provider.rb
@@ -14,6 +14,10 @@ module Saml
       find_indexed_service(descriptor.attribute_consuming_services, index)
     end
 
+    def assertion_consumer_service(index = nil)
+      find_indexed_service(descriptor.assertion_consumer_services, index)
+    end
+
     def assertion_consumer_service_indices
       if descriptor.assertion_consumer_services.present?
         descriptor.assertion_consumer_services.map(&:index)

--- a/spec/lib/saml/provider_spec.rb
+++ b/spec/lib/saml/provider_spec.rb
@@ -52,6 +52,16 @@ describe Saml::Provider do
     end
   end
 
+  describe "#assertion_consumer_service" do
+    it "returns the assertion_consumer_service" do
+      service_provider.assertion_consumer_service(0).should be_a(Saml::Elements::SPSSODescriptor::AssertionConsumerService)
+    end
+
+    it "returns the assertion_consumer_service for the default index" do
+      service_provider.assertion_consumer_service.should be_a Saml::Elements::SPSSODescriptor::AssertionConsumerService
+    end
+  end
+
   describe "#assertion_consumer_service_indices" do
     context "when there is an assertion consumer service" do
       it "returns an array with the indices of all assertion consumer services" do


### PR DESCRIPTION
Added the ability to easily retrieve a default AssertionConsumerService or the AssertionConsumerService specified by its index.