### PR TITLE
Add metadata publication info extension

### DIFF
--- a/lib/saml.rb
+++ b/lib/saml.rb
@@ -12,6 +12,7 @@ require "uri"
 
 module Saml
   MD_NAMESPACE       = 'urn:oasis:names:tc:SAML:2.0:metadata'
+  MD_RPI_NAMESPACE   = 'urn:oasis:names:tc:SAML:metadata:rpi'
   MD_ATTR_NAMESPACE  = 'urn:oasis:names:tc:SAML:metadata:attribute'
   SAML_NAMESPACE     = 'urn:oasis:names:tc:SAML:2.0:assertion'
   SAMLP_NAMESPACE    = 'urn:oasis:names:tc:SAML:2.0:protocol'
@@ -111,6 +112,7 @@ module Saml
     require 'saml/elements/attribute'
     require 'saml/elements/attribute_statement'
     require 'saml/elements/entity_attributes'
+    require 'saml/elements/publication_info'
     require 'saml/elements/md_extensions'
     require 'saml/elements/samlp_extensions'
     require 'saml/elements/service_name'

--- a/lib/saml/elements/md_extensions.rb
+++ b/lib/saml/elements/md_extensions.rb
@@ -8,6 +8,7 @@ module Saml
       namespace "md"
 
       has_one :entity_attributes, Saml::Elements::EntityAttributes
+      has_one :publication_info, Saml::Elements::PublicationInfo
     end
   end
 end

--- a/lib/saml/elements/publication_info.rb
+++ b/lib/saml/elements/publication_info.rb
@@ -1,0 +1,19 @@
+module Saml
+  module Elements
+    class PublicationInfo
+      include Saml::Base
+      include Saml::XMLHelpers
+
+      tag 'PublicationInfo'
+      register_namespace 'mdrpi', Saml::MD_RPI_NAMESPACE
+      namespace 'mdrpi'
+
+      attribute :publisher, String, :tag => 'publisher'
+      attribute :creation_instant, Time, :tag => 'creationInstant', on_save: lambda { |val| val.utc.xmlschema if val.present? }
+      attribute :publication_id, String, :tag => 'publicationId'
+
+      validates :publisher, :presence => true
+
+    end
+  end
+end

--- a/spec/factories/all.rb
+++ b/spec/factories/all.rb
@@ -180,5 +180,9 @@ FactoryGirl.define do
     telephone_numbers ["0612345678"]
     email_addresses ["technical@example.com"]
   end
-end
 
+  factory :publication_info, :class => Saml::Elements::PublicationInfo do
+    publisher "http://idp.example.com/metadata"
+    creation_instant { Time.now }
+  end
+end

--- a/spec/lib/saml/elements/md_extensions_spec.rb
+++ b/spec/lib/saml/elements/md_extensions_spec.rb
@@ -11,7 +11,7 @@ describe Saml::Elements::MDExtensions do
   end
 
   describe "Optional fields" do
-    [:entity_attributes].each do |field|
+    [:entity_attributes, :publication_info].each do |field|
       it "should have the #{field} field" do
         subject.should respond_to(field)
       end

--- a/spec/lib/saml/elements/publication_info_spec.rb
+++ b/spec/lib/saml/elements/publication_info_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Saml::Elements::PublicationInfo do
+  let(:publication_info) { FactoryGirl.build(:publication_info) }
+
+  it "has a tag" do
+    described_class.tag_name.should eq "PublicationInfo"
+  end
+
+  it "has a namespace" do
+    described_class.namespace.should eq "mdrpi"
+  end
+
+  describe 'required fields' do
+    [:publisher].each do |field|
+      it "has the #{field} field" do
+        publication_info.should respond_to(field)
+      end
+
+      it "checks the presence of #{field}" do
+        publication_info.send("#{field}=", nil)
+        publication_info.should_not be_valid
+      end
+    end
+  end
+
+  describe 'optional fields' do
+    [:creation_instant, :publication_id].each do |field|
+      it "has the #{field} field" do
+        publication_info.should respond_to(field)
+      end
+
+      it "allows #{field} to be blank" do
+        publication_info.send("#{field}=", nil)
+        publication_info.should be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added the PublicationInfo element including its mdrpi (Metadata Extensions for Registration and Publication Information) namespace.