### PR TITLE
Added a second parameter to the initializer of Saml::Artifact which s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.6.8
+* enhancements
+    * added the option to set a custom endpoint index for an ```Artifact```.
+
 ### 2.6.7
 * enhancements
     * fixed a parsing bug where an unsigned ```ArtifactResponse``` received the signature of its inner signed message.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    libsaml (2.6.7)
+    libsaml (2.6.8)
       activemodel (>= 3.0.0)
       activesupport (>= 3.2.15)
       curb

--- a/lib/saml/artifact.rb
+++ b/lib/saml/artifact.rb
@@ -2,23 +2,23 @@ module Saml
   class Artifact
     include ::HappyMapper
 
-    TYPE_CODE       = "\000\004"
-    END_POINT_INDEX = "\000\000"
+    TYPE_CODE      = "\000\004"
+    ENDPOINT_INDEX = "\000\000"
 
     tag "Artifact"
     namespace 'samlp'
 
     content :artifact, String
 
-    def initialize(artifact = nil)
+    def initialize(artifact = nil, endpoint_index = ENDPOINT_INDEX)
       if artifact
         @artifact = artifact
       else
         source_id       = ::Digest::SHA1.digest(Saml.current_provider.entity_id.to_s)
         message_handle  = ::SecureRandom.random_bytes(20)
         @type_code      = TYPE_CODE
-        @endpoint_index = END_POINT_INDEX
-        @artifact   = Saml::Encoding.encode_64 [@type_code, @endpoint_index, source_id, message_handle].join
+        @endpoint_index = endpoint_index.is_a?(Numeric) ? [endpoint_index].pack("n") : endpoint_index
+        @artifact       = Saml::Encoding.encode_64 [@type_code, @endpoint_index, source_id, message_handle].join
       end
     end
 

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = "2.6.7"
+  VERSION = "2.6.8"
 end

--- a/spec/lib/saml/artifact_spec.rb
+++ b/spec/lib/saml/artifact_spec.rb
@@ -7,10 +7,6 @@ describe Saml::Artifact, "with hex encoded attributes" do
     artifact.type_code.should == "\000\004"
   end
 
-  it "should have an endpoint_index of 0x000" do
-    artifact.endpoint_index == "\000\000"
-  end
-
   it "should have a source_id of 20 bytes" do
     artifact.source_id.size == 20
   end
@@ -25,6 +21,50 @@ describe Saml::Artifact, "with hex encoded attributes" do
 
   it "should have a total length of 44 bytes" do
     Base64.decode64(artifact.to_s).size.should == 44
+  end
+
+  context "endpoint index" do
+    let(:artifact_string) { "AAQAANo5o+5ea0sNMlW/75VgGJCv2AcJbY2VGuPiI9goxi7s45u3fXoHeDE=" }
+
+    context "without any parameters" do
+      it "should have the default endpoint index of 0x0000" do
+        artifact.endpoint_index.should == "\000\000"
+      end
+    end
+
+    context "with an artifact as a parameter" do
+      let(:artifact) { Saml::Artifact.new(artifact_string) }
+
+      it "should have the default endpoint index of 0x0000" do
+        artifact.endpoint_index.should == "\000\000"
+      end
+    end
+
+    context "with an endpoint index as a parameter" do
+      context "when the endpoint index is a number" do
+        let(:artifact) { Saml::Artifact.new(nil, 1) }
+
+        it "packs the number and sets the endpoint index to 0x0001" do
+          artifact.endpoint_index.should == "\000\001"
+        end
+      end
+
+      context "when the endpoint index is not a number" do
+        let(:artifact) { Saml::Artifact.new(nil, "\000\001") }
+
+        it "sets the endpoint index to 0x0001" do
+          artifact.endpoint_index.should == "\000\001"
+        end
+      end
+    end
+
+    context "with an artifact and an endpoint index as parameters" do
+      let(:artifact) { Saml::Artifact.new(artifact_string, 1) }
+
+      it "should have the default endpoint index of 0x0000" do
+        artifact.endpoint_index.should == "\000\000"
+      end
+    end
   end
 
   describe "#parse" do


### PR DESCRIPTION
…ets the endpoint index. This can be used to set a reference to a different artifact resolution endpoint other than the default one with index 0.