### PR TITLE
Removed the http://www.w3.org/2001/XMLSchema and http://www.w3.org/20…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.8.2
+* enhancements
+    * removed the ```http://www.w3.org/2001/XMLSchema``` and ```http://www.w3.org/2001/XMLSchema-instance``` namespaces from the ```to_soap``` method.
+
 ### 2.8.1
 * enhancements
     * changed the ```#attribute_value=``` method on ```ComplexTypes::AttributeValue``` so it will replace the existing attribute values, instead of appending to it

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    libsaml (2.8.1)
+    libsaml (2.8.2)
       activemodel (>= 3.0.0)
       activesupport (>= 3.2.15)
       curb

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = "2.8.1"
+  VERSION = "2.8.2"
 end

--- a/lib/saml/xml_helpers.rb
+++ b/lib/saml/xml_helpers.rb
@@ -26,9 +26,7 @@ module Saml
       body    = self.to_xml(builder)
 
       builder = Nokogiri::XML::Builder.new(:encoding => "UTF-8")
-      builder.Envelope(:'xmlns:soapenv' => "http://schemas.xmlsoap.org/soap/envelope/",
-                       :'xmlns:xsd'     => Saml::XS_NAMESPACE,
-                       :'xmlns:xsi'     => Saml::XSI_NAMESPACE) do |xml|
+      builder.Envelope(:'xmlns:soapenv' => "http://schemas.xmlsoap.org/soap/envelope/") do |xml|
         builder.parent.namespace = builder.parent.namespace_definitions.find { |n| n.prefix == 'soapenv' }
         builder.Body do
           builder.parent.add_child body.doc.root


### PR DESCRIPTION
…01/XMLSchema-instance namespaces from the to_soap method since they’re not used there anyway.