### PR TITLE
Added the #attribute_service_url helper method to Saml::Provider to e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.10.4
+* enhancements
+    * added `attribute_service_url` to `Saml::Provider`
+
 ### 2.10.3
 * enhancements
     * added an `Advice`` element and it’s ```AdviceType``` complex type

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    libsaml (2.10.3)
+    libsaml (2.10.4)
       activemodel (>= 3.0.0)
       activesupport (>= 3.2.15)
       curb

--- a/lib/saml/provider.rb
+++ b/lib/saml/provider.rb
@@ -59,6 +59,10 @@ module Saml
       find_binding_service(descriptor.single_logout_services, binding)
     end
 
+    def attribute_service_url(binding)
+      find_binding_service(entity_descriptor.attribute_authority_descriptor.attribute_service, binding)
+    end
+
     def type
       descriptor.is_a?(Saml::Elements::SPSSODescriptor) ? "service_provider" : "identity_provider"
     end

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = "2.10.3"
+  VERSION = "2.10.4"
 end

--- a/spec/lib/saml/provider_spec.rb
+++ b/spec/lib/saml/provider_spec.rb
@@ -18,9 +18,19 @@ class IdentityProvider
   end
 end
 
+class AuthorityProvider
+  include Saml::Provider
+
+  def initialize
+    @entity_descriptor = Saml::Elements::EntityDescriptor.parse(File.read("spec/fixtures/metadata/authority_provider.xml"))
+    @private_key = OpenSSL::PKey::RSA.new(File.read("spec/fixtures/key.pem"))
+  end
+end
+
 describe Saml::Provider do
   let(:service_provider) { ServiceProvider.new }
   let(:identity_provider) { IdentityProvider.new }
+  let(:authority_provider) { AuthorityProvider.new }
 
   describe "#assertion_consumer_service_url" do
     it "returns the url for the given index" do
@@ -59,6 +69,12 @@ describe Saml::Provider do
 
     it "returns the assertion_consumer_service for the default index" do
       service_provider.assertion_consumer_service.should be_a Saml::Elements::SPSSODescriptor::AssertionConsumerService
+    end
+  end
+
+  describe "#attribute_service_url" do
+    it "returns the attribute service url for the specified binding" do
+      authority_provider.attribute_service_url(Saml::ProtocolBinding::SOAP).should == "https://idp.example.com/SAML/AA/URI"
     end
   end
 


### PR DESCRIPTION
…asily retrieve the location of an AttributeService by the specified binding.