### PR TITLE
Added the AttributeAuthorithyDescriptor as a descriptor for the Provi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.10.6
+* enhancements
+    * added `AttributeAuthorithyDescriptor` as a descriptor for the Provider, which now returns a `Saml::ComplexTypes::RoleDescriptorType` instead of a `Saml::ComplexTypes::SSODescriptorType`
+
 ### 2.10.5
 * enhancements
     * add a new ```SubjectConfirmation``` element as an Array when a ```Subject``` is initialized

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    libsaml (2.10.5)
+    libsaml (2.10.6)
       activemodel (>= 3.0.0)
       activesupport (>= 3.2.15)
       curb

--- a/lib/saml/provider.rb
+++ b/lib/saml/provider.rb
@@ -87,9 +87,9 @@ module Saml
       end
     end
 
-    # @return [Saml::ComplexTypes::SSODescriptorType]
+    # @return [Saml::ComplexTypes::RoleDescriptorType]
     def descriptor
-      entity_descriptor.sp_sso_descriptor || entity_descriptor.idp_sso_descriptor
+      entity_descriptor.sp_sso_descriptor || entity_descriptor.idp_sso_descriptor || entity_descriptor.attribute_authority_descriptor
     end
 
     def find_indexed_service_url(service_list, index)

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = "2.10.5"
+  VERSION = "2.10.6"
 end


### PR DESCRIPTION
…der, which now returns a Saml::ComplexTypes::RoleDescriptorType instead of a Saml::ComplexTypes::SSODescriptorType (which it already did through the SSODescriptorType, but we’re more specific now).