### PR TITLE
Prevent multiple Assertions and it’s elements being added as associat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.12.0
+* enhancements
+    * prevent multiple ```Assertion``` elements and it’s elements being added as associations to the root element when there are nested ```Assertion``` elements.
+
 ### 2.11.2
 * enhancements
     * added the `fetch_attribute_value` helper method to `Assertion` and `AttributeStatement`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    libsaml (2.11.2)
+    libsaml (2.12.0)
       activemodel (>= 3.0.0)
       activesupport (>= 3.2.15)
       curb
@@ -183,3 +183,6 @@ DEPENDENCIES
   rspec-collection_matchers (~> 1.0)
   rspec-rails (~> 3.1)
   simplecov
+
+BUNDLED WITH
+   1.10.6

--- a/lib/saml/assertion.rb
+++ b/lib/saml/assertion.rb
@@ -15,13 +15,13 @@ module Saml
 
     element :issuer, String, :namespace => 'saml', :tag => 'Issuer'
 
-    has_one   :signature, Saml::Elements::Signature
-    has_one   :subject, Saml::Elements::Subject
-    has_one   :conditions, Saml::Elements::Conditions
-    has_one   :advice, Saml::Elements::Advice
-    has_many  :statements, Saml::ComplexTypes::StatementAbstractType
-    has_many  :authn_statement, Saml::Elements::AuthnStatement
-    has_many  :attribute_statements, Saml::Elements::AttributeStatement
+    has_one   :signature, Saml::Elements::Signature, xpath: './'
+    has_one   :subject, Saml::Elements::Subject, xpath: './'
+    has_one   :conditions, Saml::Elements::Conditions, xpath: './'
+    has_one   :advice, Saml::Elements::Advice, xpath: './'
+    has_many  :statements, Saml::ComplexTypes::StatementAbstractType, xpath: './'
+    has_many  :authn_statement, Saml::Elements::AuthnStatement, xpath: './'
+    has_many  :attribute_statements, Saml::Elements::AttributeStatement, xpath: './'
 
     validates :_id, :version, :issue_instant, :issuer, :presence => true
 

--- a/lib/saml/response.rb
+++ b/lib/saml/response.rb
@@ -3,7 +3,7 @@ module Saml
     include Saml::ComplexTypes::StatusResponseType
 
     tag "Response"
-    has_many :assertions, Saml::Assertion
+    has_many :assertions, Saml::Assertion, xpath: './'
     has_many :encrypted_assertions, Saml::Elements::EncryptedAssertion
 
     def authn_failed?
@@ -52,6 +52,6 @@ module Saml
 
     def encrypted_assertion=(encrypted_assertion)
       (self.encrypted_assertions ||= []) << encrypted_assertion
-     end
+    end
   end
 end

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = "2.11.2"
+  VERSION = "2.12.0"
 end

--- a/spec/fixtures/artifact_response.xml
+++ b/spec/fixtures/artifact_response.xml
@@ -28,8 +28,60 @@
       </saml:Conditions>
       <saml:Advice>
         <saml:Assertion Version="2.0" ID="_aaaf655219464fb403b34436cfb0c5cb1d9a5847" IssueInstant="1970-01-01T01:33:31+01:00">
+          <saml:Issuer>Provider Bar</saml:Issuer>
+          <saml:Subject>
+            <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">s00000000:123456789</saml:NameID>
+            <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+              <saml:SubjectConfirmationData NotOnOrAfter="2011-08-31T08:51:05Z" Recipient="https://sp.example.com/assertion_consumer" InResponseTo="_13603a6565a69297e9809175b052d115965121c8" />
+            </saml:SubjectConfirmation>
+          </saml:Subject>
+          <saml:Conditions NotOnOrAfter="2011-08-31T08:51:05Z" NotBefore="2011-08-31T08:51:05Z">
+            <saml:AudienceRestriction>
+              <saml:Audience>ServiceProvider</saml:Audience>
+            </saml:AudienceRestriction>
+          </saml:Conditions>
+          <saml:Statement>
+          </saml:Statement>
+          <saml:AuthnStatement AuthnInstant="2011-08-31T08:51:05Z" SessionIndex="_93af655219464fb403b34436cfb0c5cb1d9a5502">
+            <saml:AuthnContext>
+              <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+            </saml:AuthnContext>
+            <saml:SubjectLocality Address="127.0.0.1"/>
+          </saml:AuthnStatement>
+          <saml:AttributeStatement>
+            <saml:Attribute Name="urn:ServiceID">
+              <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">2</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute Name="urn:EntityConcernedID">
+              <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">1</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute Name="urn:EntityConcernedSubID">
+              <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">1</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:EncryptedAttribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+              <xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Type="http://www.w3.org/2001/04/xmlenc#Element" Id="_AA9625AF68B4FC078CC7582D28D05D9C">
+                <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                  <xenc:EncryptedKey>
+                    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+                    <ds:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+                      <ds:KeyName>aa355fbd1f624503c5c9677402ecca00ef1f6277</ds:KeyName>
+                    </ds:KeyInfo>
+                    <xenc:CipherData>
+                      <xenc:CipherValue>K0mBLxfLziKVUKEAOYe7D6uVSCPy8vyWVh3RecnPES+8QkAhOuRSuE/LQpFr0huI/iCEy9pde1QgjYDLtjHcujKi2xGqW6jkXW/EuKomqWPPA2xYs1fpB1su4aXUOQB6OJ70/oDcOsy834ghFaBWilE8fqyDBUBvW+2IvaMUZabwN/s9mVkWzM3r30tlkhLK7iOrbGAldIHwFU5z7PPR6RO3Y3fIxjHU40OnLsJc3xIqdLH3fXpC0kgi5UspLdq14e5OoXjLoPG3BO3zwOAIJ8XNBWY5uQof6KrKbcvtZSY0fMvPYhYfNjtRFy8y49ovL9fwjCRTDlT5+aHqsCTBrw==</xenc:CipherValue>
+                    </xenc:CipherData>
+                  </xenc:EncryptedKey>
+                </ds:KeyInfo>
+                <xenc:CipherData>
+                  <xenc:CipherValue>ZzCu6axGgAYZHVf77NX8apZKB/GJDeuV6bFByBS0AIgiXkvDUAmLCpabTAWBM+yz19olA6rryuOfr82ev2bzPNURvm4SYxahvuL4Pibn5wJky0Bl54VqmcU+Aqj0dAvOgqG1y3X4wO9n9bRsTv6921m0eqRAFph8kK8L9hirK1BxYBYj2RyFCoFDPxVZ5wyra3q4qmE4/ELQpFP6mfU8LXb0uoWJUjGUelS2Aa7bZis8zEpwov4CwtlNjltQih4mv7ttCAfYqcQIFzBTB+DAa0+XggxCLcdB3+mQiRcECBfwHHJ7gRmnuBEgeWT3CGKa3Nb7GMXOfuxFKF5pIehWgo3kdNQLalor8RVW6I8P/I8fQ33Fe+NsHVnJ3zwSA//a</xenc:CipherValue>
+                </xenc:CipherData>
+              </xenc:EncryptedData>
+            </saml:EncryptedAttribute>
+          </saml:AttributeStatement>
         </saml:Assertion>
       </saml:Advice>
+      <saml:Statement>
+      </saml:Statement>
       <saml:AuthnStatement AuthnInstant="2011-08-31T08:51:05Z" SessionIndex="_93af655219464fb403b34436cfb0c5cb1d9a5502">
         <saml:AuthnContext>
           <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>

--- a/spec/fixtures/attribute_statement.xml
+++ b/spec/fixtures/attribute_statement.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<saml:AttributeStatement xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+  <saml:Attribute Name="urn:ServiceID">
+    <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">1</saml:AttributeValue>
+  </saml:Attribute>
+  <saml:Attribute Name="urn:EntityConcernedID">
+    <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">1</saml:AttributeValue>
+  </saml:Attribute>
+  <saml:Attribute Name="urn:EntityConcernedSubID">
+    <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">1</saml:AttributeValue>
+  </saml:Attribute>
+  <saml:EncryptedAttribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+    <xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Type="http://www.w3.org/2001/04/xmlenc#Element" Id="_F39625AF68B4FC078CC7582D28D05D9C">
+      <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <xenc:EncryptedKey>
+          <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+          <ds:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+            <ds:KeyName>62355fbd1f624503c5c9677402ecca00ef1f6277</ds:KeyName>
+          </ds:KeyInfo>
+          <xenc:CipherData>
+            <xenc:CipherValue>K0mBLxfLziKVUKEAOYe7D6uVSCPy8vyWVh3RecnPES+8QkAhOuRSuE/LQpFr0huI/iCEy9pde1QgjYDLtjHcujKi2xGqW6jkXW/EuKomqWPPA2xYs1fpB1su4aXUOQB6OJ70/oDcOsy834ghFaBWilE8fqyDBUBvW+2IvaMUZabwN/s9mVkWzM3r30tlkhLK7iOrbGAldIHwFU5z7PPR6RO3Y3fIxjHU40OnLsJc3xIqdLH3fXpC0kgi5UspLdq14e5OoXjLoPG3BO3zwOAIJ8XNBWY5uQof6KrKbcvtZSY0fMvPYhYfNjtRFy8y49ovL9fwjCRTDlT5+aHqsCTBrw==</xenc:CipherValue>
+          </xenc:CipherData>
+        </xenc:EncryptedKey>
+      </ds:KeyInfo>
+      <xenc:CipherData>
+        <xenc:CipherValue>ZzCu6axGgAYZHVf77NX8apZKB/GJDeuV6bFByBS0AIgiXkvDUAmLCpabTAWBM+yz19olA6rryuOfr82ev2bzPNURvm4SYxahvuL4Pibn5wJky0Bl54VqmcU+Aqj0dAvOgqG1y3X4wO9n9bRsTv6921m0eqRAFph8kK8L9hirK1BxYBYj2RyFCoFDPxVZ5wyra3q4qmE4/ELQpFP6mfU8LXb0uoWJUjGUelS2Aa7bZis8zEpwov4CwtlNjltQih4mv7ttCAfYqcQIFzBTB+DAa0+XggxCLcdB3+mQiRcECBfwHHJ7gRmnuBEgeWT3CGKa3Nb7GMXOfuxFKF5pIehWgo3kdNQLalor8RVW6I8P/I8fQ33Fe+NsHVnJ3zwSA//a</xenc:CipherValue>
+      </xenc:CipherData>
+    </xenc:EncryptedData>
+  </saml:EncryptedAttribute>
+</saml:AttributeStatement>

--- a/spec/lib/saml/assertion_spec.rb
+++ b/spec/lib/saml/assertion_spec.rb
@@ -104,14 +104,26 @@ describe Saml::Assertion do
       expect(assertion.advice).to be_a(Saml::Elements::Advice)
     end
 
-    it "should parse AuthnStatement" do
-      assertion.authn_statement.first.should be_a(Saml::Elements::AuthnStatement)
+    it 'parses Statement elements' do
+      aggregate_failures do
+        expect(assertion.statements.size).to eq 1
+        expect(assertion.statements.first).to be_a(Saml::ComplexTypes::StatementAbstractType)
+      end
     end
 
-    it "should parse AttributeStatement" do
-      assertion.attribute_statement.should be_a(Saml::Elements::AttributeStatement)
+    it 'parses AuthnStatement elements' do
+      aggregate_failures do
+        expect(assertion.authn_statement.size).to eq 1
+        expect(assertion.authn_statement.first).to be_a(Saml::Elements::AuthnStatement)
+      end
     end
 
+    it 'parses AttributeStatement elements' do
+      aggregate_failures do
+        expect(assertion.attribute_statements.size).to eq 1
+        expect(assertion.attribute_statements.first).to be_a(Saml::Elements::AttributeStatement)
+      end
+    end
   end
 
   describe "provider" do

--- a/spec/lib/saml/elements/attribute_statement_spec.rb
+++ b/spec/lib/saml/elements/attribute_statement_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Saml::Elements::AttributeStatement do
-  let(:attribute_statement_xml) { File.read(File.join('spec', 'fixtures', 'artifact_response.xml')) }
+  let(:attribute_statement_xml) { File.read(File.join('spec', 'fixtures', 'attribute_statement.xml')) }
   let(:attribute_statement) { Saml::Elements::AttributeStatement.parse(attribute_statement_xml, :single => true) }
 
   describe '#parse' do

--- a/spec/lib/saml/response_spec.rb
+++ b/spec/lib/saml/response_spec.rb
@@ -31,8 +31,11 @@ describe Saml::Response do
       response.should be_a(Saml::Response)
     end
 
-    it "should parse the Assertion" do
-      response.assertion.should be_a(Saml::Assertion)
+    it 'parses Assertion elements' do
+      aggregate_failures do
+        expect(response.assertions.count).to eq 1
+        expect(response.assertion).to be_a(Saml::Assertion)
+      end
     end
 
     it "should parse multiple assertions" do
@@ -148,9 +151,7 @@ describe Saml::Response do
   end
 
   describe 'encrypted assertions' do
-    let(:response) do
-      response = Saml::Response.new(encrypted_assertion: Saml::Elements::EncryptedAssertion.new)
-    end
+    let(:response) { Saml::Response.new(encrypted_assertion: Saml::Elements::EncryptedAssertion.new) }
 
     it 'should have one encrypted assertion' do
       response.encrypted_assertions.count.should == 1


### PR DESCRIPTION
…ions to the root element when there are nested Assertions, since the Advice and Evidence elements may contain other Assertions.

For example:
When an Assertion of a Response element contains an Advice element which contains another Assertion, the nested Assertion of the Advice element got assigned to the Response element. Therefore the Response element would have 2 Assertions instead of 1.