### PR TITLE
Do not invoke `provider.authn_requests_signed?` unless provider is a SP

### DIFF
--- a/lib/saml/bindings/http_redirect.rb
+++ b/lib/saml/bindings/http_redirect.rb
@@ -19,7 +19,10 @@ module Saml
           redirect_binding = new(request_or_response, options)
           query_string     = URI.parse(http_request.url).query
 
-          redirect_binding.verify_signature(query_string) if request_or_response.provider.authn_requests_signed?
+          provider = request_or_response.provider
+          if provider.type.to_s == "service_provider" && provider.authn_requests_signed?
+            redirect_binding.verify_signature(query_string)
+          end
 
           request_or_response.actual_destination = http_request.url
           request_or_response

--- a/spec/lib/saml/bindings/http_redirect_spec.rb
+++ b/spec/lib/saml/bindings/http_redirect_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Saml::Bindings::HTTPRedirect do
   let(:authn_request) { build(:authn_request, _id: "id", issuer: "https://sp.example.com", issue_instant: Time.at(0), destination: "http://example.com/sso") }
   let(:logout_response) { build(:logout_response, _id: "id", issuer: "https://sp.example.com", issue_instant: Time.at(0), destination: "http://example.com/sso") }
+  let(:logout_response_idp) { build(:logout_response, _id: "id", issuer: "https://idp.example.com", issue_instant: Time.at(0), destination: "https://sp.example.com/sso/logout") }
 
   let(:url) do
     described_class.create_url(authn_request,
@@ -117,6 +118,28 @@ describe Saml::Bindings::HTTPRedirect do
         Saml::BasicProvider.any_instance.stub(:authn_requests_signed?).and_return(false)
         Saml::BasicProvider.any_instance.stub(:verify).and_return(false)
         described_class.receive_message(request, type: :authn_request).should be_a(Saml::AuthnRequest)
+      end
+    end
+
+    context "with an IDP issued message" do
+      let(:url) do
+        described_class.create_url(logout_response_idp,
+                                   relay_state:         "https//example.com/relay",
+                                   signature_algorithm: "http://www.w3.org/2000/09/xmldsig#rsa-sha1")
+      end
+
+      let(:params) { Saml::Util.parse_params(url) }
+
+      let(:parsed_params) do
+        params.inject({}) { |h, (k, v)| h[k] = CGI.unescape(v); h }
+      end
+
+      let(:response) do
+        double(:response, params: parsed_params, url: url)
+      end
+
+      it 'parses the message correctly' do
+        described_class.receive_message(response, type: :logout_response).should be_a(Saml::LogoutResponse)
       end
     end
   end


### PR DESCRIPTION
Otherwise, we will get a missing method error when we try to parse a `SAMLResponse` of `LogoutResponse` type issued by an IDP.