### PR TITLE
Allows for the optional specification of SessionIndex in LogoutRequest

### DIFF
--- a/lib/saml.rb
+++ b/lib/saml.rb
@@ -125,6 +125,7 @@ module Saml
     require 'saml/elements/encrypted_attribute'
     require 'saml/elements/name_id'
     require 'saml/elements/name_id_format'
+    require 'saml/elements/session_index'
     require 'saml/elements/encrypted_id'
     require 'saml/elements/attribute_value'
     require 'saml/elements/attribute'

--- a/lib/saml/elements/session_index.rb
+++ b/lib/saml/elements/session_index.rb
@@ -1,0 +1,13 @@
+module Saml
+  module Elements
+    class SessionIndex
+      include Saml::Base
+
+      tag 'SessionIndex'
+      register_namespace 'samlp', Saml::SAMLP_NAMESPACE
+      namespace 'samlp'
+
+      content :value, String
+    end
+  end
+end

--- a/lib/saml/logout_request.rb
+++ b/lib/saml/logout_request.rb
@@ -9,6 +9,7 @@ module Saml
     attribute :not_on_or_after, Time, :tag => "NotOnOrAfter", :on_save => lambda { |val| val.utc.xmlschema if val.present? }
 
     element :name_id, String, :tag => "NameID", :namespace => 'saml'
+    element :session_index, String, :tag => "SessionIndex", :namespace => 'samlp'
 
     validates :name_id, :presence => true
   end

--- a/spec/factories/all.rb
+++ b/spec/factories/all.rb
@@ -237,4 +237,8 @@ FactoryGirl.define do
   factory :name_id, class: Saml::Elements::NameId do
     value 'NameID'
   end
+
+  factory :session_index, class: Saml::Elements::SessionIndex do
+    value 'SessionIndex'
+  end
 end

--- a/spec/fixtures/logout_request.xml
+++ b/spec/fixtures/logout_request.xml
@@ -4,4 +4,5 @@
                      ID="_43faa9487db98daa757214c2d233d31a8ac043be" IssueInstant="2011-08-31T08:54:36+02:00">
   <saml:Issuer>ServiceProvider</saml:Issuer>
   <saml:NameID>s00000000:123456789</saml:NameID>
+  <samlp:SessionIndex>123456789123456789123456789123456789</samlp:SessionIndex>
 </samlp:LogoutRequest>

--- a/spec/lib/saml/elements/session_index_spec.rb
+++ b/spec/lib/saml/elements/session_index_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe Saml::Elements::SessionIndex do
+
+  it "has a tag" do
+    described_class.tag_name.should eq "SessionIndex"
+  end
+
+  it "has a namespace" do
+    described_class.namespace.should eq "samlp"
+  end
+end

--- a/spec/lib/saml/logout_request_spec.rb
+++ b/spec/lib/saml/logout_request_spec.rb
@@ -12,7 +12,7 @@ describe Saml::LogoutRequest do
   end
 
   describe "Optional fields" do
-    [:not_on_or_after].each do |field|
+    [:not_on_or_after, :session_index].each do |field|
       it "should have the #{field} field" do
         logout_request.should respond_to(field)
       end
@@ -50,6 +50,10 @@ describe Saml::LogoutRequest do
 
     it "should parse name_id" do
       logout_request.name_id.should == "s00000000:123456789"
+    end
+
+    it "should parse session_index" do
+      logout_request.session_index.should == "123456789123456789123456789123456789"
     end
   end
 


### PR DESCRIPTION
The optional SessionIndex element may be needed by some IDPs; this patch allows for that element to be included in LogoutRequests.

See: https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf LINE 2545