### PR TITLE
Call #canonicalize on the signed node instead of #to_xml so that the …

### DIFF
--- a/lib/saml/util.rb
+++ b/lib/saml/util.rb
@@ -105,7 +105,7 @@ module Saml
 
         signed_node = document.signed_nodes.find { |node| node['ID'] == message._id }
 
-        message.class.parse(signed_node.to_xml, single: true)
+        message.class.parse(signed_node.canonicalize, single: true)
       end
 
       def collect_extra_namespaces(raw_xml)

--- a/spec/lib/saml/util_spec.rb
+++ b/spec/lib/saml/util_spec.rb
@@ -255,6 +255,16 @@ describe Saml::Util do
       end
     end
 
+    describe 'authn request within an artifact response' do
+      let(:artifact_response) { Saml::ArtifactResponse.new authn_request: Saml::AuthnRequest.new.tap(&:add_signature) }
+      let(:signed_xml) { Saml::Util.sign_xml(artifact_response) }
+
+      let(:authn_request) { Saml::AuthnRequest.parse signed_xml, single: true }
+
+      it 'parses the authn request from the signed XML without an undefined samlp prefix error' do
+        Saml::Util.verify_xml(authn_request, signed_xml).should be_a(Saml::AuthnRequest)
+      end
+    end
   end
 
   describe '.encrypt_assertion' do


### PR DESCRIPTION
…original namespaces of the inner element are placed back when parsed.