### PR TITLE
#audience and #audience= were created as a backwards compatible optio…

### DIFF
--- a/lib/saml/elements/audience_restriction.rb
+++ b/lib/saml/elements/audience_restriction.rb
@@ -9,11 +9,11 @@ module Saml
       has_many :audiences, Saml::Elements::Audience
 
       def audience
-        Array(audiences).first
+        Array(audiences).first.try(:value)
       end
 
-      def audience=(audience)
-        self.audiences = [audience]
+      def audience=(value)
+        self.audiences = [ Saml::Elements::Audience.new(value: value) ]
       end
     end
   end

--- a/spec/factories/all.rb
+++ b/spec/factories/all.rb
@@ -123,6 +123,10 @@ FactoryGirl.define do
 
   end
 
+  factory :audience, :class => Saml::Elements::Audience do
+
+  end
+
   factory :audience_restriction, :class => Saml::Elements::AudienceRestriction do
 
   end

--- a/spec/lib/saml/elements/audience_restriction_spec.rb
+++ b/spec/lib/saml/elements/audience_restriction_spec.rb
@@ -21,7 +21,7 @@ describe Saml::Elements::AudienceRestriction do
 
   describe '#audience' do
     context 'when there are audiences' do
-      before { allow(audience_restriction).to receive(:audiences).and_return ['AuthorityProvider', 'ServiceProvider'] }
+      before { allow(audience_restriction).to receive(:audiences).and_return [ build(:audience, value: 'AuthorityProvider'), build(:audience, value: 'ServiceProvider') ] }
 
       it 'returns the first audience' do
         expect(audience_restriction.audience).to eq 'AuthorityProvider'
@@ -29,7 +29,7 @@ describe Saml::Elements::AudienceRestriction do
     end
 
     context 'when there is only one audience' do
-      before { allow(audience_restriction).to receive(:audiences).and_return ['ServiceProvider'] }
+      before { allow(audience_restriction).to receive(:audiences).and_return [ build(:audience, value: 'ServiceProvider') ] }
 
       it 'returns the audience' do
         expect(audience_restriction.audience).to eq 'ServiceProvider'
@@ -55,7 +55,7 @@ describe Saml::Elements::AudienceRestriction do
         expect(audience_restriction.audiences).to contain_exactly an_instance_of(Saml::Elements::Audience), an_instance_of(Saml::Elements::Audience)
         expect(audience_restriction.audiences.map(&:value)).to match_array ['ServiceProvider', 'AuthorityProvider']
 
-        audience_restriction.audience = Saml::Elements::Audience.new(value: 'IdentityProvider')
+        audience_restriction.audience = 'IdentityProvider'
         expect(audience_restriction.audiences.count).to eq 1
         expect(audience_restriction.audiences).to contain_exactly an_instance_of(Saml::Elements::Audience)
         expect(audience_restriction.audiences.map(&:value)).to match_array ['IdentityProvider']


### PR DESCRIPTION
…n for the change in #78, but its implementation was actually incorrect as mentioned by @suhrawardi in https://github.com/digidentity/libsaml/commit/c5bff339bd2a25601bdd257a8c8d79c9f78b2a79#commitcomment-14867307.

This fixes that.