### PR TITLE
Add proxy option for HTTP artifact resolution

### DIFF
--- a/lib/saml/bindings/http_artifact.rb
+++ b/lib/saml/bindings/http_artifact.rb
@@ -30,11 +30,12 @@ module Saml
           Saml::Util.verify_xml(artifact_resolve, raw_xml)
         end
 
-        def resolve(request, location)
+        def resolve(request, location, additional_headers = {}, proxy = {})
           artifact         = request.params["SAMLart"]
           artifact_resolve = Saml::ArtifactResolve.new(artifact: artifact, destination: location)
 
-          response = Saml::Util.post(location, notify('create_post', Saml::Util.sign_xml(artifact_resolve, :soap)))
+          message = notify('create_post', Saml::Util.sign_xml(artifact_resolve, :soap))
+          response = Saml::Util.post(location, message, additional_headers, proxy)
 
           if response.code == "200"
             notify('receive_response', response.body)

--- a/lib/saml/util.rb
+++ b/lib/saml/util.rb
@@ -14,10 +14,12 @@ module Saml
         params
       end
 
-      def post(location, message, additional_headers = {})
+      def post(location, message, additional_headers = {}, proxy = {})
         uri = URI.parse(location)
+        default_proxy_settings = { addr: :ENV, port: nil, user: nil, pass: nil }
+        proxy = default_proxy_settings.merge(proxy)
 
-        http             = Net::HTTP.new(uri.host, uri.port)
+        http             = Net::HTTP.new(uri.host, uri.port, proxy[:addr], proxy[:port], proxy[:user], proxy[:pass])
         http.use_ssl     = uri.scheme == 'https'
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 

--- a/spec/lib/saml/bindings/http_artifact_spec.rb
+++ b/spec/lib/saml/bindings/http_artifact_spec.rb
@@ -117,7 +117,7 @@ describe Saml::Bindings::HTTPArtifact do
 
       it "sends the artifact_resolve to the identity provider" do
         uri = URI.parse(identity_provider.artifact_resolution_service_url)
-        Net::HTTP.should_receive(:new).with(uri.host, uri.port).and_return double.as_null_object
+        Net::HTTP.should_receive(:new).with(uri.host, uri.port, :ENV, nil, nil, nil).and_return double.as_null_object
         described_class.resolve(request, identity_provider.artifact_resolution_service_url)
         @request.path.should == "/sso/resolve_artifact"
       end

--- a/spec/lib/saml/bindings/soap_spec.rb
+++ b/spec/lib/saml/bindings/soap_spec.rb
@@ -58,7 +58,7 @@ describe Saml::Bindings::SOAP do
 
       it "sends the logout_request to the request destination" do
         uri = URI.parse(logout_request.destination)
-        Net::HTTP.should_receive(:new).with(uri.host, uri.port).and_return double.as_null_object
+        Net::HTTP.should_receive(:new).with(uri.host, uri.port, :ENV, nil, nil, nil).and_return double.as_null_object
         described_class.post_message(logout_request, :logout_response)
         @request.path.should == "/logout"
       end

--- a/spec/lib/saml/util_spec.rb
+++ b/spec/lib/saml/util_spec.rb
@@ -127,6 +127,13 @@ describe Saml::Util do
       described_class.post location, message, additional_headers
     end
 
+    it "can use a proxy" do
+      proxy = { addr: '127.0.0.1', port: 8888, user: 'someuser', pass: 'somepass' }
+
+      Net::HTTP.should_receive(:new).with("example.com", 80, proxy[:addr], proxy[:port], proxy[:user], proxy[:pass]).and_return(net_http)
+      described_class.post location, message, {}, proxy
+    end
+
     context 'default settings' do
       before do
         Net::HTTP.stub(:new).and_return(net_http)
@@ -158,6 +165,11 @@ describe Saml::Util do
 
       it "doesn't use the private key" do
         net_http.should_not_receive(:key=)
+        post_request
+      end
+
+      it "doesn't use proxy settings" do
+        Net::HTTP.should_receive(:new).with('example.com', 80, :ENV, nil, nil, nil)
         post_request
       end
     end


### PR DESCRIPTION
Our application requires the use of a proxy to resolve HTTP artifacts. We would like to avoid setting the `http_proxy` environment variable to achieve this. I've modified `HTTPArtifact#resolve` to also take in `additional_headers` and `proxy` arguments. This should not break existing code.