### PR TITLE
Added option to add a custom subject to an Assertion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.20.1
+* Added the option to set a custom `subject` in the assertion
+
 ### 2.19.10
 * Added the InclusiveNamespaces #prefix_list to the config
 

--- a/lib/saml/assertion.rb
+++ b/lib/saml/assertion.rb
@@ -32,10 +32,15 @@ module Saml
 
     def initialize(*args)
       options          = args.extract_options!
-      @subject         = Saml::Elements::Subject.new(:name_id        => options.delete(:name_id),
-                                                     :name_id_format => options.delete(:name_id_format),
-                                                     :recipient      => options.delete(:recipient),
-                                                     :in_response_to => options.delete(:in_response_to))
+      if options[:subject].present?
+        @subject = options.delete(:subject)
+      else
+        @subject         = Saml::Elements::Subject.new(:name_id        => options.delete(:name_id),
+                                                       :name_id_format => options.delete(:name_id_format),
+                                                       :recipient      => options.delete(:recipient),
+                                                       :in_response_to => options.delete(:in_response_to))
+      end
+
       @conditions      = Saml::Elements::Conditions.new(:audience => options.delete(:audience))
       @authn_statement = Saml::Elements::AuthnStatement.new(:authn_instant           => Time.now,
                                                             :address                 => options.delete(:address),

--- a/lib/saml/elements/subject.rb
+++ b/lib/saml/elements/subject.rb
@@ -17,23 +17,25 @@ module Saml
 
       def initialize(*args)
         options               = args.extract_options!
-        @_name_id             = Saml::Elements::NameId.new(format: options.delete(:name_id_format),
-                                                           value:  options.delete(:name_id))
+        if options[:name_id].present?
+          @_name_id             = Saml::Elements::NameId.new(format: options.delete(:name_id_format),
+                                                             value:  options.delete(:name_id))
+        end
         @subject_confirmations = [Saml::Elements::SubjectConfirmation.new(recipient:      options.delete(:recipient),
                                                                           in_response_to: options.delete(:in_response_to))]
         super(*(args << options))
       end
 
       def name_id
-        @_name_id.value
+        @_name_id.try(:value)
       end
 
       def name_id=(value)
-        @_name_id.value = value
+        @_name_id.value = value if @_name_id
       end
 
       def name_id_format
-        @_name_id.format
+        @_name_id.try(:format)
       end
 
       def subject_confirmation

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = "2.20.0"
+  VERSION = "2.20.1"
 end

--- a/spec/lib/saml/assertion_spec.rb
+++ b/spec/lib/saml/assertion_spec.rb
@@ -153,6 +153,15 @@ describe Saml::Assertion do
       assertion = Saml::Assertion.new(:authn_context_class_ref => "authn_context")
       assertion.authn_statement.authn_context.authn_context_class_ref.should == "authn_context"
     end
+
+    context 'subject is specified' do
+      subject { described_class.new(subject: assertion_subject) }
+      let(:assertion_subject) { ::Saml::Elements::Subject.new(value: 'TEST') }
+
+      it 'should set #subject to the specified subject' do
+        expect(subject.subject).to eq assertion_subject
+      end
+    end
   end
 
   describe "IssueInstant" do

--- a/spec/lib/saml/elements/subject_spec.rb
+++ b/spec/lib/saml/elements/subject_spec.rb
@@ -66,6 +66,38 @@ describe Saml::Elements::Subject do
     end
   end
 
+  describe '.initialize' do
+    subject { described_class.new(params) }
+
+    context 'name_id is specified' do
+      let(:params) { { name_id: 'TEST', name_id_format: 'format' } }
+
+      it 'adds a name_id' do
+        expect(subject._name_id).to be_a Saml::Elements::NameId
+      end
+
+      it '#name_id equals the given value' do
+        expect(subject.name_id).to eq 'TEST'
+      end
+
+      it '#name_id_format equals the given format' do
+        expect(subject.name_id_format).to eq 'format'
+      end
+    end
+
+    context 'no name_id is specified' do
+      let(:params) { {} }
+
+      it '#name_id is nil' do
+        expect(subject.name_id).to eq nil
+      end
+
+      it '#name_id_format is nil' do
+        expect(subject.name_id_format).to eq nil
+      end
+    end
+  end
+
   describe '#subject_confirmation' do
     let(:subject_confirmation_1) { FactoryGirl.build(:subject_confirmation) }
     let(:subject_confirmation_2) { FactoryGirl.build(:subject_confirmation) }


### PR DESCRIPTION
Subject does not create an empty NameID anymore when no name_id is given.
Bumped version and updated changelog.