### PR TITLE
Add #ssl_private_key and #ssl_certificate_file to the Config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.20.3
+* Added #ssl_private_key and #ssl_certificate to the config.
+
+### 2.20.2
+* Only convert the not_before and not_on_or_after to the XML schema format when there is a value.
+
 ### 2.20.1
 * Added the option to set a custom `subject` in the assertion
 

--- a/lib/saml/config.rb
+++ b/lib/saml/config.rb
@@ -6,11 +6,11 @@ module Saml
     mattr_accessor :max_issue_instant_offset
     @@max_issue_instant_offset = 2
 
-    mattr_accessor :ssl_private_key_file
-    @@ssl_private_key_file = nil
+    mattr_accessor :ssl_private_key
+    @@ssl_private_key = nil
 
-    mattr_accessor :ssl_certificate_file
-    @@ssl_certificate_file = nil
+    mattr_accessor :ssl_certificate
+    @@ssl_certificate = nil
 
     mattr_accessor :http_ca_file
     @@http_ca_file = nil
@@ -27,7 +27,25 @@ module Saml
       registered_stores[name] = store
       self.default_store = name if options[:default]
     end
-
     module_function :register_store
+
+    def ssl_private_key_file=(private_key_file)
+      if private_key_file.present?
+        self.ssl_private_key = OpenSSL::PKey::RSA.new File.read(private_key_file)
+      else
+        self.ssl_private_key = nil
+      end
+    end
+    module_function :ssl_private_key_file=
+
+    def ssl_certificate_file=(certificate_file)
+      if certificate_file.present?
+        self.ssl_certificate = OpenSSL::X509::Certificate.new File.read(certificate_file)
+      else
+        self.ssl_certificate = nil
+      end
+    end
+    module_function :ssl_certificate_file=
+
   end
 end

--- a/lib/saml/util.rb
+++ b/lib/saml/util.rb
@@ -154,12 +154,10 @@ module Saml
       end
 
       def add_ssl_certificate_and_key(http)
-        return http unless Saml::Config.ssl_certificate_file.present?
-        return http unless Saml::Config.ssl_private_key_file.present?
-        cert = File.read(Saml::Config.ssl_certificate_file)
-        key  = File.read(Saml::Config.ssl_private_key_file)
-        http.cert = OpenSSL::X509::Certificate.new(cert)
-        http.key  = OpenSSL::PKey::RSA.new(key)
+        return http unless Saml::Config.ssl_certificate.present?
+        return http unless Saml::Config.ssl_private_key.present?
+        http.key  = Saml::Config.ssl_private_key
+        http.cert = Saml::Config.ssl_certificate
         http
       end
     end

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = "2.20.2"
+  VERSION = '2.20.3'
 end

--- a/spec/lib/saml/config_spec.rb
+++ b/spec/lib/saml/config_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Saml::Config do
+
+  let(:private_key_file) { File.join('spec', 'fixtures', 'key.pem') }
+  let(:private_key)      { OpenSSL::PKey::RSA.new(File.read(private_key_file)) }
+
+  let(:certificate_file) { File.join('spec', 'fixtures', 'certificate.pem') }
+  let(:certificate)      { OpenSSL::X509::Certificate.new(File.read(certificate_file)) }
+
+  after do
+    Saml::Config.ssl_private_key = nil
+    Saml::Config.ssl_certificate = nil
+  end
+
+  describe '#ssl_private_key_file' do
+    it 'initializes an OpenSSL::PKey::RSA' do
+      expect(OpenSSL::PKey::RSA).to receive(:new).with File.read(private_key_file)
+      Saml::Config.ssl_private_key_file = private_key_file
+    end
+
+    it 'sets #ssl_private_key' do
+      allow(OpenSSL::PKey::RSA).to receive(:new).and_return 'key'
+      Saml::Config.ssl_private_key_file = private_key_file
+      expect(Saml::Config.ssl_private_key).to eq 'key'
+    end
+  end
+
+  describe '#ssl_private_key' do
+    it 'sets #ssl_private_key' do
+      Saml::Config.ssl_private_key = private_key
+      expect(Saml::Config.ssl_private_key).to eq private_key
+    end
+  end
+
+  describe '#ssl_certificate_file' do
+    it 'initializes an OpenSSL::X509::Certificate' do
+      expect(OpenSSL::X509::Certificate).to receive(:new).with File.read(certificate_file)
+      Saml::Config.ssl_certificate_file = certificate_file
+    end
+
+    it 'sets #ssl_certificate' do
+      allow(OpenSSL::X509::Certificate).to receive(:new).and_return 'cert'
+      Saml::Config.ssl_certificate_file = certificate_file
+      expect(Saml::Config.ssl_certificate).to eq 'cert'
+    end
+  end
+
+  describe '#ssl_certificate' do
+    it 'sets #ssl_certificate' do
+      Saml::Config.ssl_certificate = certificate
+      expect(Saml::Config.ssl_certificate).to eq certificate
+    end
+  end
+
+end

--- a/spec/lib/saml/util_spec.rb
+++ b/spec/lib/saml/util_spec.rb
@@ -179,6 +179,9 @@ describe Saml::Util do
       let(:key_file) { File.join('spec', 'fixtures', 'key.pem') }
 
       before :each do
+        allow(OpenSSL::X509::Certificate).to receive(:new).and_return('cert')
+        allow(OpenSSL::PKey::RSA).to receive(:new).and_return('key')
+
         Saml::Config.ssl_certificate_file = certificate_file
         Saml::Config.ssl_private_key_file = key_file
 
@@ -191,13 +194,11 @@ describe Saml::Util do
       end
 
       it 'sets the certificate' do
-        OpenSSL::X509::Certificate.stub(:new).and_return('cert')
         net_http.should_receive(:cert=).with('cert')
         post_request
       end
 
       it 'sets the private key' do
-        OpenSSL::PKey::RSA.stub(:new).and_return('key')
         net_http.should_receive(:key=).with('key')
         post_request
       end


### PR DESCRIPTION
- The private key can now be configured by #ssl_private_key which must be an OpenSSL::PKey::RSA.
- The certificate can now be configured with #ssl_certificate which must be an OpenSSL::X509::Certificate.

The existing #ssl_private_key_file and #ssl_certificate_file methods are only used to set the private key and certificate.