### PR TITLE
Fixed HTTP-Redirect signature verification always using SAMLRequest

### DIFF
--- a/lib/saml/bindings/http_redirect.rb
+++ b/lib/saml/bindings/http_redirect.rb
@@ -75,7 +75,7 @@ module Saml
         end
 
         relay_state = params["RelayState"] ? "&RelayState=#{params['RelayState']}" : ""
-        "#{param_key}=#{params['SAMLRequest']}#{relay_state}&SigAlg=#{params['SigAlg']}"
+        "#{param_key}=#{params[param_key]}#{relay_state}&SigAlg=#{params['SigAlg']}"
       end
 
       def encoded_message


### PR DESCRIPTION
Signature verification for any `SAMLResponse` always fails because the wrong key was read from `request.params`.

I didn't add any tests because it seems a little silly just to duplicate the whole suite of tests for `HTTPRedirect` for responses instead of only requests.