### PR TITLE
Added possiblity to set the prefix_list on InclusiveNamespaces

### DIFF
--- a/lib/saml/elements/signature.rb
+++ b/lib/saml/elements/signature.rb
@@ -24,7 +24,7 @@ module Saml
       def initialize(*args)
         super(*args)
         options      = args.extract_options!
-        @signed_info ||= SignedInfo.new(:uri => options.delete(:uri), :digest_value => options.delete(:digest_value))
+        @signed_info ||= SignedInfo.new(:uri => options.delete(:uri), :digest_value => options.delete(:digest_value), :inclusive_namespaces => options.delete(:inclusive_namespaces))
       end
 
       def key_name

--- a/lib/saml/elements/signature/inclusive_namespaces.rb
+++ b/lib/saml/elements/signature/inclusive_namespaces.rb
@@ -11,7 +11,8 @@ module Saml
         attribute :prefix_list, String, :tag => "PrefixList"
 
         def initialize(*args)
-          @prefix_list = Saml::Config.inclusive_namespaces_prefix_list
+          options = args.extract_options!
+          @prefix_list = options[:prefix_list] || Saml::Config.inclusive_namespaces_prefix_list
           super(*args)
         end
       end

--- a/lib/saml/elements/signature/reference.rb
+++ b/lib/saml/elements/signature/reference.rb
@@ -13,7 +13,8 @@ module Saml
         element :digest_value, String, :tag => "DigestValue", :state_when_nil => true
 
         def initialize(*args)
-          @transforms    = Transforms.new
+          options = args.extract_options!
+          @transforms    = Transforms.new(:inclusive_namespaces => options.delete(:inclusive_namespaces))
           @digest_method = DigestMethod.new
           super(*args)
         end

--- a/lib/saml/elements/signature/signed_info.rb
+++ b/lib/saml/elements/signature/signed_info.rb
@@ -16,7 +16,8 @@ module Saml
           @signature_method        = SignatureMethod.new
           super(*args)
           options    = args.extract_options!
-          @reference ||= Reference.new(:uri => options.delete(:uri), :digest_value => options.delete(:digest_value))
+
+          @reference ||= Reference.new(:uri => options.delete(:uri), :digest_value => options.delete(:digest_value), :inclusive_namespaces => options.delete(:inclusive_namespaces))
         end
       end
     end

--- a/lib/saml/elements/signature/transforms.rb
+++ b/lib/saml/elements/signature/transforms.rb
@@ -10,9 +10,10 @@ module Saml
         has_many :transform, Transform, :tag => "Transform"
 
         def initialize(*args)
+          options = args.extract_options!
           @transform = [Transform.new(:algorithm => "http://www.w3.org/2000/09/xmldsig#enveloped-signature"),
                         Transform.new(:algorithm            => "http://www.w3.org/2001/10/xml-exc-c14n#",
-                                      :inclusive_namespaces => InclusiveNamespaces.new)]
+                                      :inclusive_namespaces => InclusiveNamespaces.new(:prefix_list => options[:inclusive_namespaces]))]
           super(*args)
         end
       end

--- a/spec/lib/saml/elements/signature/inclusive_namespaces_spec.rb
+++ b/spec/lib/saml/elements/signature/inclusive_namespaces_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::InclusiveNamespaces do
+  before { Saml::Config.inclusive_namespaces_prefix_list = 'XXX' }
+
+  context 'no prefix_list passed as argument' do
+    it 'uses the globally configured prefix_list' do
+      expect(subject.prefix_list).to eq Saml::Config.inclusive_namespaces_prefix_list
+    end
+  end
+
+  context 'a prefix_list is passed as an argument' do
+    subject { described_class.new(:prefix_list => 'ARG') }
+
+    it 'uses the given prefix_list' do
+      expect(subject.prefix_list).to eq 'ARG'
+    end
+  end
+end

--- a/spec/lib/saml/elements/signature/reference_spec.rb
+++ b/spec/lib/saml/elements/signature/reference_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::Reference do
+  let(:inclusive_namespaces) { 'ARG' }
+  subject { described_class.new :inclusive_namespaces => inclusive_namespaces }
+
+  it 'passes the given inclusive_namespaces to Transforms' do
+    expect(::Saml::Elements::Signature::Transforms).to receive(:new).with(:inclusive_namespaces => inclusive_namespaces)
+    subject
+  end
+end

--- a/spec/lib/saml/elements/signature/signed_info_spec.rb
+++ b/spec/lib/saml/elements/signature/signed_info_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::SignedInfo do
+  let(:inclusive_namespaces) { 'ARG' }
+  subject { described_class.new :inclusive_namespaces => inclusive_namespaces }
+
+  it 'passes the given inclusive_namespaces to the Reference element' do
+    expect(::Saml::Elements::Signature::Reference).to receive(:new).with(including(:inclusive_namespaces => inclusive_namespaces))
+    subject
+  end
+end

--- a/spec/lib/saml/elements/signature/transforms_spec.rb
+++ b/spec/lib/saml/elements/signature/transforms_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::Transforms do
+  let(:inclusive_namespaces) { 'ARG' }
+  before { Saml::Config.inclusive_namespaces_prefix_list = 'XXX' }
+
+  context 'no inclusive_namespaces passed as argument' do
+    it 'uses the globally configured prefix_list' do
+      expect(subject.transform.last.inclusive_namespaces.prefix_list).to eq Saml::Config.inclusive_namespaces_prefix_list
+    end
+  end
+
+  context 'inclusive_namespaces is passed as an argument' do
+    subject { described_class.new(:inclusive_namespaces => 'ARG') }
+
+    it 'uses the given inclusive_namespaces as prefix_list' do
+      expect(subject.transform.last.inclusive_namespaces.prefix_list).to eq 'ARG'
+    end
+  end
+end

--- a/spec/lib/saml/elements/signature_spec.rb
+++ b/spec/lib/saml/elements/signature_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::SignedInfo do
+  let(:inclusive_namespaces) { 'ARG' }
+  subject { described_class.new :inclusive_namespaces => inclusive_namespaces }
+
+  it 'passes the given inclusive_namespaces to the Reference element' do
+    expect(::Saml::Elements::Signature::SignedInfo).to receive(:new).with(including(:inclusive_namespaces => inclusive_namespaces))
+    subject
+  end
+end


### PR DESCRIPTION
instead of configuring a global one.

  Passing inclusive_namespaces to SignedInfo from the Signature.

  Pass the `prefix_list` arg to InclusiveNamespaces

  Pass the `inclusive_namespaces` arg to Reference

  Pass the `inclusive_namespaces` arg to Transforms

  Pass the `inclusive_namespaces` arg to SignedInfo