### PR TITLE
Added possiblity to set the prefix_list on InclusiveNamespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.20.7
+* Added `inclusive_namespaces_prefix_list` param to Signature to specify a custom inclusive_namespaces_prefix_list instead of the global one in config.
+
 ### 2.20.6
 * added config options `generate_key_name` to disable automatic keyname generation
 * improved the key info lookup for role descriptors

--- a/lib/saml/elements/signature.rb
+++ b/lib/saml/elements/signature.rb
@@ -22,9 +22,9 @@ module Saml
       has_one :key_info, KeyInfo
 
       def initialize(*args)
-        super(*args)
         options      = args.extract_options!
-        @signed_info ||= SignedInfo.new(:uri => options.delete(:uri), :digest_value => options.delete(:digest_value))
+        @signed_info ||= SignedInfo.new(:uri => options.delete(:uri), :digest_value => options.delete(:digest_value), :inclusive_namespaces_prefix_list => options.delete(:inclusive_namespaces_prefix_list))
+        super(*(args << options))
       end
 
       def key_name

--- a/lib/saml/elements/signature/reference.rb
+++ b/lib/saml/elements/signature/reference.rb
@@ -13,9 +13,10 @@ module Saml
         element :digest_value, String, :tag => "DigestValue", :state_when_nil => true
 
         def initialize(*args)
-          @transforms    = Transforms.new
-          @digest_method = DigestMethod.new
           super(*args)
+          options = args.extract_options!
+          @transforms    = Transforms.new(:inclusive_namespaces_prefix_list => options[:inclusive_namespaces_prefix_list])
+          @digest_method = DigestMethod.new
         end
       end
     end

--- a/lib/saml/elements/signature/signed_info.rb
+++ b/lib/saml/elements/signature/signed_info.rb
@@ -14,9 +14,9 @@ module Saml
         def initialize(*args)
           @canonicalization_method = CanonicalizationMethod.new
           @signature_method        = SignatureMethod.new
-          super(*args)
           options    = args.extract_options!
-          @reference ||= Reference.new(:uri => options.delete(:uri), :digest_value => options.delete(:digest_value))
+          @reference ||= Reference.new(:uri => options.delete(:uri), :digest_value => options.delete(:digest_value), :inclusive_namespaces_prefix_list => options.delete(:inclusive_namespaces_prefix_list))
+          super(*(args << options))
         end
       end
     end

--- a/lib/saml/elements/signature/transforms.rb
+++ b/lib/saml/elements/signature/transforms.rb
@@ -10,10 +10,11 @@ module Saml
         has_many :transform, Transform, :tag => "Transform"
 
         def initialize(*args)
+          options = args.extract_options!
           @transform = [Transform.new(:algorithm => "http://www.w3.org/2000/09/xmldsig#enveloped-signature"),
                         Transform.new(:algorithm            => "http://www.w3.org/2001/10/xml-exc-c14n#",
-                                      :inclusive_namespaces => InclusiveNamespaces.new)]
-          super(*args)
+                                      :inclusive_namespaces => InclusiveNamespaces.new(:prefix_list => options.delete(:inclusive_namespaces_prefix_list)))]
+          super(*(args << options))
         end
       end
     end

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = '2.20.6'
+  VERSION = '2.20.7'
 end

--- a/spec/lib/saml/elements/signature/inclusive_namespaces_spec.rb
+++ b/spec/lib/saml/elements/signature/inclusive_namespaces_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::InclusiveNamespaces do
+  subject { described_class.new(:prefix_list => inclusive_namespaces) }
+  before { Saml::Config.inclusive_namespaces_prefix_list = 'XXX' }
+
+  context 'no prefix_list passed as argument' do
+    let(:inclusive_namespaces) { nil }
+
+    it 'uses the globally configured prefix_list' do
+      expect(subject.prefix_list).to eq 'XXX'
+    end
+  end
+
+  context 'a prefix_list is passed as an argument' do
+    let(:inclusive_namespaces) { 'ARG' }
+
+    it 'uses the given prefix_list' do
+      expect(subject.prefix_list).to eq 'ARG'
+    end
+  end
+end

--- a/spec/lib/saml/elements/signature/reference_spec.rb
+++ b/spec/lib/saml/elements/signature/reference_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::Reference do
+  let(:inclusive_namespaces) { 'ARG' }
+  subject { described_class.new :inclusive_namespaces_prefix_list => inclusive_namespaces }
+
+  it 'passes the given inclusive_namespaces to Transforms' do
+    expect(::Saml::Elements::Signature::Transforms).to receive(:new).with(:inclusive_namespaces_prefix_list => inclusive_namespaces)
+    subject
+  end
+end

--- a/spec/lib/saml/elements/signature/signed_info_spec.rb
+++ b/spec/lib/saml/elements/signature/signed_info_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::SignedInfo do
+  let(:inclusive_namespaces) { 'ARG' }
+  subject { described_class.new :inclusive_namespaces_prefix_list => inclusive_namespaces }
+
+  it 'passes the given inclusive_namespaces to the Reference element' do
+    expect(::Saml::Elements::Signature::Reference).to receive(:new).with(including(:inclusive_namespaces_prefix_list => inclusive_namespaces))
+    subject
+  end
+end

--- a/spec/lib/saml/elements/signature/transforms_spec.rb
+++ b/spec/lib/saml/elements/signature/transforms_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::Reference do
+  let(:inclusive_namespaces) { 'ARG' }
+  subject { described_class.new :inclusive_namespaces_prefix_list => inclusive_namespaces }
+
+  it 'passes the given inclusive_namespaces to Transforms' do
+    expect(::Saml::Elements::Signature::InclusiveNamespaces).to receive(:new).with(:prefix_list => inclusive_namespaces)
+    subject
+  end
+end

--- a/spec/lib/saml/elements/signature_spec.rb
+++ b/spec/lib/saml/elements/signature_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe ::Saml::Elements::Signature::SignedInfo do
+  let(:inclusive_namespaces) { 'ARG' }
+  subject { described_class.new :inclusive_namespaces_prefix_list => inclusive_namespaces }
+
+  it 'passes the given inclusive_namespaces to the Reference element' do
+    expect(::Saml::Elements::Signature::SignedInfo).to receive(:new).with(including(:inclusive_namespaces_prefix_list => inclusive_namespaces))
+    subject
+  end
+end


### PR DESCRIPTION
instead of configuring a global one by passing `inclusive_namespaces_prefix_list` to the Signature.

    Signature passing inclusive_namespaces_prefix_list to SignedInfo element.

    SignedInfo passing inclusive_namespaces_prefix_list to Reference element.

    Reference passing inclusive_namespaces_prefix_list to Transforms element.

    Transforms setting InclusiveNamespaces #prefix_list.

Bumped version and updated changelog.