### PR TITLE
Make sure the OpenSSL error queue is cleared after failed certificate signature verification

### DIFF
--- a/lib/saml/provider.rb
+++ b/lib/saml/provider.rb
@@ -89,7 +89,12 @@ module Saml
     end
 
     def verify(signature_algorithm, signature, data, key_name = nil)
-      certificate(key_name).public_key.verify(digest_method(signature_algorithm).new, signature, data) rescue nil
+      valid = certificate(key_name).public_key.verify(digest_method(signature_algorithm).new, signature, data) rescue nil
+
+      # Clear OpenSSL error queue if verification fails - https://bugs.ruby-lang.org/issues/7215
+      OpenSSL.errors if !valid
+
+      valid
     end
 
     def authn_requests_signed?

--- a/spec/lib/saml/provider_spec.rb
+++ b/spec/lib/saml/provider_spec.rb
@@ -53,6 +53,13 @@ describe Saml::Provider do
   let(:authority_provider) { AuthorityProvider.new }
   let(:identity_and_service_provider) { IdentityAndServiceProvider.new }
 
+  describe "#verify" do
+    it "clears the OpenSSL error queue after a verification returns false" do
+      expect(service_provider_with_signing_key.verify('sha1', 'some-invalid-sigature', 'some-document')).to eq(false)
+      expect(OpenSSL.errors).to be_empty
+    end
+  end
+
   describe "#assertion_consumer_service_url" do
     it "returns the url for the given index" do
       service_provider.assertion_consumer_service_url(0).should == "https://sp.example.com/sso/receive_artifact"


### PR DESCRIPTION
We are using libsaml in a rails app with a database connection through the `pg` gem.  When saml signature verification fails, it leaves an error in the current thread's OpenSSL error queue, which can cause the `pg` gem to throw an exception.

See https://bugs.ruby-lang.org/issues/7215 for more detailed information.

The workaround is to call `OpenSSL.errors`, which calls https://www.openssl.org/docs/manmaster/crypto/ERR_get_error.html in succession until the error queue is cleared (https://github.com/ruby/ruby/blob/trunk/ext/openssl/ossl.c#L363).

It's possible that this is a backward incompatible change if any users are relying on `OpenSSL.errors` to inspect the verification errors, as subsequent calls to `OpenSSL.errors` will be empty now.
However, I believe if those users need a method for retrieving the error messages, it may be best to provide a way to pass the information from `OpenSSL.errors` into the `Saml::Errors::SignatureInvalid` object that is raised in `Util.verify_xml`.