### PR TITLE
change delimiter for appending url parameters in redirect if existing parameters are present

### DIFF
--- a/lib/saml/bindings/http_redirect.rb
+++ b/lib/saml/bindings/http_redirect.rb
@@ -58,7 +58,10 @@ module Saml
       end
 
       def create_url
-        [request_or_response.destination, signed_params].join("?")
+        url = request_or_response.destination
+        delimiter = url.include?('?') ? '&' : '?'
+
+        [url, signed_params].join(delimiter)
       end
 
       private


### PR DESCRIPTION
Thanks for the quick review and merge of my last PR 😄.  Here is another small code change to get libsaml working with Google's IDP.  When integrating with Google, the SSO url has an existing query parameter (https://accounts.google.com/o/saml2/idp?idpid=xxx), which causes an error due to the `SAMLRequest` parameter being appended with a `?` instead of a `&`.

This PR changes the redirect url creation to check for existing parameters, and append the SAML parameters with the correct delimiter.