### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ class SamlController < ActionController::Base
     authn_request = if request.get?
       Saml::Bindings::HTTPRedirect.receive_message(request, type: :authn_request)
     elsif request.post?
-      Saml::Bindings::HTTPPost.receive_message(request, type: :authn_request)
+      Saml::Bindings::HTTPPost.receive_message(request, :authn_request)
     else
       return head :not_allowed
     end


### PR DESCRIPTION
Remove keyword argument from "Saml::Bindings::HTTPPost.receive_message" method in "Using libsaml as an IDP" section. The second argument for Saml::Bindings::HTTPPost.receive_message does not have a 'type:' keyword argument (https://github.com/digidentity/libsaml/blob/master/lib/saml/bindings/http_post.rb#L22)