### PR TITLE
Passing string to :if and :unless conditional options on callbacks is deprecated in Rails 5.1.

### DIFF
--- a/lib/saml/assertion.rb
+++ b/lib/saml/assertion.rb
@@ -28,7 +28,7 @@ module Saml
     validates :_id, :version, :issue_instant, :issuer, :presence => true
 
     validates :version, inclusion: %w(2.0)
-    validate :check_issue_instant, :if => 'issue_instant.present?'
+    validate :check_issue_instant, :if => lambda { |val| val.issue_instant.present? }
 
     def initialize(*args)
       options          = args.extract_options!

--- a/lib/saml/authn_request.rb
+++ b/lib/saml/authn_request.rb
@@ -16,7 +16,9 @@ module Saml
     has_one :requested_authn_context, Saml::Elements::RequestedAuthnContext
 
     validates :force_authn, :inclusion => [true, false, nil]
-    validates :assertion_consumer_service_index, :numericality => true, :if => "assertion_consumer_service_index.present?"
+    validates :assertion_consumer_service_index, :numericality => true, :if => lambda { |val|
+      val.assertion_consumer_service_index.present?
+    }
 
     validate :check_assertion_consumer_service
 

--- a/lib/saml/complex_types/request_abstract_type.rb
+++ b/lib/saml/complex_types/request_abstract_type.rb
@@ -28,8 +28,10 @@ module Saml
         validates :_id, :version, :issue_instant, presence: true
 
         validates :version, inclusion: %w(2.0)
-        validate :check_destination, if: 'destination.present? && actual_destination.present?'
-        validate :check_issue_instant, if: 'issue_instant.present?'
+        validate :check_destination, if: lambda { |val|
+          val.destination.present? && val.actual_destination.present?
+        }
+        validate :check_issue_instant, if: lambda { |val| val.issue_instant.present? }
       end
 
       def initialize(*args)


### PR DESCRIPTION
Replaced deprecated style to lambda.

ref.) https://github.com/rails/rails/blob/master/activesupport/CHANGELOG.md#rails-510beta1-february-23-2017