### PR TITLE
Also allow 0.6.y versions of xmldsig

### DIFF
--- a/saml.gemspec
+++ b/saml.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activemodel", ">= 4.2"
   s.add_dependency "xmlmapper", '~> 0.7.2'
   s.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.8'
-  s.add_dependency "xmldsig", '~> 0.5.1'
+  s.add_dependency "xmldsig", '>= 0.5.1', '< 0.7.0'
   s.add_dependency "xmlenc", '~> 0.6.2'
 
   s.add_development_dependency "coveralls", "~> 0.7"


### PR DESCRIPTION
We want to upgrade our application to Nokogiri 1.7.1, but xmldsig 0.5.y version has tied it to 1.6.y. We have no problems with the 0.6.y versions (breaking change is default to SHA256 hash). Since xmldsig is still in the 0.x version scheme, I put the upper limit to one minor version higher.

BTW, this file is committed with Windows line endings