### PR TITLE
Sign encrypted data with multiple recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.0.6
+* Fix the encryption of an EncryptedID element with multiple recipients.
+
 ### 3.0.3
 * Use lambda for validations
 

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = '3.0.5'
+  VERSION = '3.0.6'
 end

--- a/saml.gemspec
+++ b/saml.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "xmlmapper", '~> 0.7.2'
   s.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.8'
   s.add_dependency "xmldsig", '>= 0.5.1', '< 0.7.0'
-  s.add_dependency "xmlenc", '>= 0.6.2', '< 0.7.0'
+  s.add_dependency "xmlenc", '>= 0.6.9', '< 0.7.0'
 
   s.add_development_dependency "coveralls", "~> 0.7"
 end

--- a/spec/lib/saml/elements/encrypted_id_spec.rb
+++ b/spec/lib/saml/elements/encrypted_id_spec.rb
@@ -63,25 +63,41 @@ describe Saml::Elements::EncryptedID do
       it 'encrypts the encrypted ID for the given key descriptor' do
         aggregate_failures do
           expect(encrypted_id.encrypted_data).to be_a Xmlenc::Builder::EncryptedData
+          expect(encrypted_id.encrypted_data.key_info.retrieval_method).to be_present
+          expect(encrypted_id.encrypted_data.key_info.key_name).to be_nil
+
           expect(encrypted_id.encrypted_keys.count).to eq 1
           expect(encrypted_id.encrypted_keys.first).to be_a Xmlenc::Builder::EncryptedKey
           expect(encrypted_id.encrypted_keys.first.key_info.key_name).to eq '22cd8e9f32a7262d2f49f5ccc518ccfbf8441bb8'
+          expect(encrypted_id.encrypted_keys.first.carried_key_name).to be_nil
+
           expect(encrypted_id.name_id).to be_nil
         end
       end
     end
 
     context 'when multiple key descriptors are given' do
-      before { encrypted_id.encrypt(key_descriptors) }
+      let(:key_name) { 'some_key_name' }
+
+      before { encrypted_id.encrypt(key_descriptors, { id: '_some_id', key_name: key_name }) }
 
       it 'encrypts the encrypted ID for each given key descriptor' do
         aggregate_failures do
           expect(encrypted_id.encrypted_data).to be_a Xmlenc::Builder::EncryptedData
+          expect(encrypted_id.encrypted_data.key_info.retrieval_method).to be_nil
+          expect(encrypted_id.encrypted_data.key_info.key_name).to eq key_name
+
           expect(encrypted_id.encrypted_keys.count).to eq 2
+
           expect(encrypted_id.encrypted_keys.first).to be_a Xmlenc::Builder::EncryptedKey
           expect(encrypted_id.encrypted_keys.first.key_info.key_name).to eq '22cd8e9f32a7262d2f49f5ccc518ccfbf8441bb8'
+          expect(encrypted_id.encrypted_keys.first.carried_key_name).to eq key_name
+
           expect(encrypted_id.encrypted_keys.second).to be_a Xmlenc::Builder::EncryptedKey
           expect(encrypted_id.encrypted_keys.second.key_info.key_name).to eq '82cd8e9f32a7262d2f49f5ccc518ccfbf8441bb8'
+          expect(encrypted_id.encrypted_keys.second.carried_key_name).to eq key_name
+
+          expect(encrypted_id.encrypted_keys.first.id).not_to eq encrypted_id.encrypted_keys.second.id
           expect(encrypted_id.name_id).to be_nil
         end
       end


### PR DESCRIPTION
"In scenarios where the encrypted element is being “multicast” to multiple recipients, and the key used to encrypt the message must be in turn encrypted individually and independently for each of the multiple recipients, the <xenc:CarriedKeyName> element SHOULD be used to assign a common name to each of the <xenc:EncryptedKey> elements so that a <ds:KeyName> can be used from within the <xenc:EncryptedData> element’s <ds:KeyInfo> element."