### PR TITLE
Backward compatibility fix.

### DIFF
--- a/lib/saml/basic_provider.rb
+++ b/lib/saml/basic_provider.rb
@@ -3,7 +3,7 @@ module Saml
     include Provider
     attr_accessor :entity_descriptor, :encryption_key, :type
 
-    def initialize(entity_descriptor, encryption_key, type, signing_key)
+    def initialize(entity_descriptor, encryption_key, type, signing_key=nil)
       @entity_descriptor = entity_descriptor
       @encryption_key    = encryption_key
       @type              = type


### PR DESCRIPTION
The signing key already defaults to the encryption key, so this should be safe.

Also see discussion in https://github.com/digidentity/libsaml/commit/b745646c33f3ba70da1fd1f98a501e143347a6f1