### PR TITLE
allow specifying NameFormat & FriendlyName at Saml::Assertion#add_attribute

### DIFF
--- a/lib/saml/assertion.rb
+++ b/lib/saml/assertion.rb
@@ -59,11 +59,13 @@ module Saml
       @provider ||= Saml.provider(issuer)
     end
 
-    def add_attribute(key, value, value_attributes = {})
+    def add_attribute(key, value, value_attributes = {}, attribute_options = {})
       self.attribute_statement ||= Saml::Elements::AttributeStatement.new
       self.attribute_statement.attributes ||= []
       attribute_value = Saml::Elements::AttributeValue.new(value_attributes.merge(content: value))
-      self.attribute_statement.attributes << Saml::Elements::Attribute.new(name: key, attribute_value: attribute_value)
+      self.attribute_statement.attributes << Saml::Elements::Attribute.new(
+        attribute_options.merge(name: key, attribute_value: attribute_value)
+      )
     end
 
     def fetch_attribute(key)

--- a/spec/lib/saml/assertion_spec.rb
+++ b/spec/lib/saml/assertion_spec.rb
@@ -202,6 +202,24 @@ describe Saml::Assertion do
       end
     end
 
+    context 'with an attribute_options added' do
+      it 'adds them to the attribute' do
+        assertion.add_attribute(
+          'key', 'value', {
+            type: 'xsi:string'
+          }, {
+            friendly_name: 'eduPersonPrincipalName',
+            format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri'
+          }
+        )
+
+        aggregate_failures do
+          expect(assertion.attribute_statement.attributes.first.friendly_name).to eq 'eduPersonPrincipalName'
+          expect(assertion.attribute_statement.attributes.first.format).to eq 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri'
+        end
+      end
+    end
+
     context 'when there are multiple attribute statements' do
       before { assertion.attribute_statements = [Saml::Elements::AttributeStatement.new, Saml::Elements::AttributeStatement.new] }
 


### PR DESCRIPTION
Hi,

I'm developing an SAML IdP which also support Shibboleth.
In that use-case, I need these option.

Cheers