### PR TITLE
NameId#SPNameQualifier and AttributeValue#NameId for Shibboleth support

### DIFF
--- a/lib/saml/assertion.rb
+++ b/lib/saml/assertion.rb
@@ -59,17 +59,19 @@ module Saml
       @provider ||= Saml.provider(issuer)
     end
 
-    def add_attribute(key, value, value_attributes = {}, attribute_options = {})
+    def add_attribute(key, value_or_values, value_attributes = {}, attribute_options = {})
       self.attribute_statement ||= Saml::Elements::AttributeStatement.new
       self.attribute_statement.attributes ||= []
-      attribute_value = case value
+      attribute_values = case value_or_values
       when Saml::Elements::NameId
-        Saml::Elements::AttributeValue.new(value_attributes.merge(name_id: value))
+        [Saml::Elements::AttributeValue.new(value_attributes.merge(name_id: value_or_values))]
       else
-        Saml::Elements::AttributeValue.new(value_attributes.merge(content: value))
+        Array(value_or_values).collect do |value|
+          Saml::Elements::AttributeValue.new(value_attributes.merge(content: value))
+        end
       end
       self.attribute_statement.attributes << Saml::Elements::Attribute.new(
-        attribute_options.merge(name: key, attribute_value: attribute_value)
+        attribute_options.merge(name: key, attribute_values: attribute_values)
       )
     end
 

--- a/lib/saml/assertion.rb
+++ b/lib/saml/assertion.rb
@@ -62,7 +62,12 @@ module Saml
     def add_attribute(key, value, value_attributes = {}, attribute_options = {})
       self.attribute_statement ||= Saml::Elements::AttributeStatement.new
       self.attribute_statement.attributes ||= []
-      attribute_value = Saml::Elements::AttributeValue.new(value_attributes.merge(content: value))
+      attribute_value = case value
+      when Saml::Elements::NameId
+        Saml::Elements::AttributeValue.new(value_attributes.merge(name_id: value))
+      else
+        Saml::Elements::AttributeValue.new(value_attributes.merge(content: value))
+      end
       self.attribute_statement.attributes << Saml::Elements::Attribute.new(
         attribute_options.merge(name: key, attribute_value: attribute_value)
       )

--- a/lib/saml/elements/attribute_value.rb
+++ b/lib/saml/elements/attribute_value.rb
@@ -16,6 +16,7 @@ module Saml
       attribute :type, String, tag: 'xsi:type'
 
       content :content, String
+      has_one :name_id, Saml::Elements::NameId
     end
   end
 end

--- a/lib/saml/elements/name_id.rb
+++ b/lib/saml/elements/name_id.rb
@@ -9,6 +9,7 @@ module Saml
 
       attribute :format, String, :tag => "Format"
       attribute :name_qualifier, String, :tag => "NameQualifier"
+      attribute :sp_name_qualifier, String, :tag => "SPNameQualifier"
 
       content :value, String
     end

--- a/spec/lib/saml/assertion_spec.rb
+++ b/spec/lib/saml/assertion_spec.rb
@@ -236,6 +236,37 @@ describe Saml::Assertion do
         end
       end
     end
+
+    context 'when Saml::Elements::NameId is given as value' do
+      it 'adds them to the attribute' do
+        assertion.add_attribute(
+          'urn:oid:1.3.6.1.4.1.5923.1.1.1.10',
+          Saml::Elements::NameId.new(
+            name_qualifier: 'idp.example.com',
+            sp_name_qualifier: 'idp.example.com',
+            value: SecureRandom.hex(16)
+          )
+        )
+
+        aggregate_failures do
+          expect(assertion.attribute_statements.first.attributes.first.attribute_values.first.name_id).to be_instance_of Saml::Elements::NameId
+          expect(assertion.attribute_statements.first.attributes.first.attribute_values.first.content).to be_blank
+        end
+      end
+    end
+
+    context 'when Array is given as value' do
+      it 'adds them to the attribute' do
+        assertion.add_attribute(
+          'urn:oid:1.3.6.1.4.1.5923.1.5.1.1',
+          ['group1', 'group2']
+        )
+
+        aggregate_failures do
+          expect(assertion.attribute_statements.first.attributes.first.attribute_values.count).to eq 2
+        end
+      end
+    end
   end
 
   describe 'fetch_attribute' do


### PR DESCRIPTION
NameId#SPNameQualifier and AttributeValue#NameId is needed for Shibboleth's "eduPersonTargetedID" attribute.

ref.) https://www.switch.ch/aai/support/documents/attributes/edupersontargetedid/