### PR TITLE
Support NameIDPolicy element in AuthnRequest

### DIFF
--- a/lib/saml.rb
+++ b/lib/saml.rb
@@ -200,6 +200,7 @@ module Saml
     require 'saml/elements/idp_entry'
     require 'saml/elements/idp_list'
     require 'saml/elements/scoping'
+    require 'saml/elements/name_id_policy'
   end
 
   module Rails

--- a/lib/saml/authn_request.rb
+++ b/lib/saml/authn_request.rb
@@ -15,6 +15,7 @@ module Saml
 
     has_one :requested_authn_context, Saml::Elements::RequestedAuthnContext
     has_one :scoping, Saml::Elements::Scoping
+    has_one :name_id_policy, Saml::Elements::NameIdPolicy
 
     validates :force_authn, :inclusion => [true, false, nil]
     validates :assertion_consumer_service_index, :numericality => true, :if => lambda { |val|
@@ -26,6 +27,14 @@ module Saml
     def assertion_url
       return assertion_consumer_service_url if assertion_consumer_service_url
       provider.assertion_consumer_service_url(assertion_consumer_service_index) if assertion_consumer_service_index
+    end
+
+    def initialize(*args)
+      options = args.extract_options!
+      name_id_format = options.delete(:name_id_format)
+      allow_create = options.delete(:allow_create) || true
+      super(*(args << options))
+      @name_id_policy = Saml::Elements::NameIdPolicy.new(format: name_id_format, allow_create: allow_create) unless name_id_format.nil?
     end
 
     private

--- a/lib/saml/authn_request.rb
+++ b/lib/saml/authn_request.rb
@@ -29,14 +29,6 @@ module Saml
       provider.assertion_consumer_service_url(assertion_consumer_service_index) if assertion_consumer_service_index
     end
 
-    def initialize(*args)
-      options = args.extract_options!
-      name_id_format = options.delete(:name_id_format)
-      allow_create = options.delete(:allow_create) || true
-      super(*(args << options))
-      @name_id_policy = Saml::Elements::NameIdPolicy.new(format: name_id_format, allow_create: allow_create) unless name_id_format.nil?
-    end
-
     private
 
     def check_assertion_consumer_service

--- a/lib/saml/elements/name_id_policy.rb
+++ b/lib/saml/elements/name_id_policy.rb
@@ -3,7 +3,7 @@ module Saml
     class NameIdPolicy
       include Saml::Base
 
-      tag 'NameIdPolicy'
+      tag 'NameIDPolicy'
       namespace 'samlp'
 
       attribute :allow_create, Boolean, tag: "AllowCreate"

--- a/lib/saml/elements/name_id_policy.rb
+++ b/lib/saml/elements/name_id_policy.rb
@@ -1,0 +1,14 @@
+module Saml
+  module Elements
+    class NameIdPolicy
+      include Saml::Base
+
+      tag 'NameIdPolicy'
+      namespace 'samlp'
+
+      attribute :allow_create, Boolean, tag: "AllowCreate"
+      attribute :format, String, tag: "Format"
+
+    end
+  end
+end

--- a/spec/fixtures/authn_request_with_name_id_policy.xml
+++ b/spec/fixtures/authn_request_with_name_id_policy.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<samlp:AuthnRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" AssertionConsumerServiceIndex="1" Version="2.0"
+                    ID="_c392374de287c092408062878fbc23edf9bb3508" ProviderName="Provider" ForceAuthn="false"
+                    IssueInstant="2011-08-31T08:30:56+02:00"
+                    Destination="http://test.url/sso">
+  <saml:Issuer>https://sp.example.com</saml:Issuer>
+  <samlp:NameIDPolicy AllowCreate="true" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"/>
+  <samlp:RequestedAuthnContext Comparison="minimum">
+    <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+  </samlp:RequestedAuthnContext>
+  <samlp:Scoping>
+    <samlp:IDPList>
+      <samlp:IDPEntry ProviderID="provider-id-1" Name="Provider name 1" Loc="https://idp1.example.com"/>
+      <samlp:IDPEntry ProviderID="provider-id-2" Name="Provider name 2" Loc="https://idp2.example.com"/>
+    </samlp:IDPList>
+  </samlp:Scoping>
+</samlp:AuthnRequest>

--- a/spec/lib/saml/authn_request_spec.rb
+++ b/spec/lib/saml/authn_request_spec.rb
@@ -104,6 +104,18 @@ describe Saml::AuthnRequest do
     end
   end
 
+  describe "NameIDPolicy element test on AuthnRequest" do
+    let(:authn_request_xml) { File.read(File.join('spec', 'fixtures', 'authn_request_with_name_id_policy.xml')) }
+    let(:authn_request) { Saml::AuthnRequest.parse(authn_request_xml) }
+    let(:new_authn_request_xml) { authn_request.to_xml }
+    let(:new_authn_request) { Saml::AuthnRequest.parse(new_authn_request_xml) }
+
+    it "NameIDPolicy element should have correct values" do
+      new_authn_request.name_id_policy.allow_create.should == true
+      new_authn_request.name_id_policy.format.should == 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+    end
+  end
+
   describe "#assertion_url" do
 
     it "returns the url as specified" do
@@ -117,4 +129,5 @@ describe Saml::AuthnRequest do
     end
 
   end
+
 end


### PR DESCRIPTION
For certain IDP provider, `NameIDPolicy` might be required for AuthnRequest, such as Novell NIDP in my case. I have to make sure this element present to make sure SSO can work. So I added two options for AuthnRequest to allow initialize AuthnRequest with `NameIDPolicy` element, two properties will need to be passed: `format` and `allow_create`, this element will only be created if `format` property has been passed.  Usage is pretty straight forward:

```ruby
authn_request = Saml::AuthnRequest.new(destination: sso_desitination,
          assertion_consumer_service_url: callback_url,
          name_id_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
          allow_create: true)
```

The above codes will insert following element in AuthnRequest:

```xml
<samlp:NameIDPolicy AllowCreate="true" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"/>
```

Have created on test in `authn_request_spec.rb`.
