### PR TITLE
allow non-signed AuthnRequest for O365 ECP use-case.

### DIFF
--- a/lib/saml/bindings/soap.rb
+++ b/lib/saml/bindings/soap.rb
@@ -29,7 +29,16 @@ module Saml
           notify('receive_message', raw_xml)
           message = Saml.parse_message(raw_xml, type)
 
-          Saml::Util.verify_xml(message, raw_xml)
+          skip_signature_verification = (
+            message.is_a?(Saml::AuthnRequest) &&
+            !message.provider.authn_requests_signed?
+          )
+
+          if skip_signature_verification
+            message
+          else
+            Saml::Util.verify_xml(message, raw_xml)
+          end
         end
       end
     end


### PR DESCRIPTION
When using O365's ECP feature, O365 sends unsigned SOAP request to IdP's ECP endpoint.
So that this pull request allows it.

ps.
ECP is required to receive emails on mail clients which doesn't support SAML WebSSO profile (e.g., Thuderbird, Android Gmail app)

ref.) https://github.com/digidentity/libsaml/issues/159