### PR TITLE
optionally include SP certificate in encrypted assertions

### DIFF
--- a/lib/saml/response.rb
+++ b/lib/saml/response.rb
@@ -28,10 +28,10 @@ module Saml
       !success? && status.status_code.unknown_principal?
     end
 
-    def encrypt_assertions(certificate)
+    def encrypt_assertions(certificate, include_certificate: false)
       @encrypted_assertions = []
       assertions.each do |assertion|
-        @encrypted_assertions << Saml::Util.encrypt_assertion(assertion, certificate)
+        @encrypted_assertions << Saml::Util.encrypt_assertion(assertion, certificate, include_certificate: include_certificate)
       end
       assertions.clear
     end

--- a/lib/saml/util.rb
+++ b/lib/saml/util.rb
@@ -60,7 +60,7 @@ module Saml
         end
       end
 
-      def encrypt_assertion(assertion, key_descriptor_or_certificate)
+      def encrypt_assertion(assertion, key_descriptor_or_certificate, include_certificate: false)
         case key_descriptor_or_certificate
         when OpenSSL::X509::Certificate
           certificate = key_descriptor_or_certificate
@@ -80,11 +80,12 @@ module Saml
         encrypted_key = encrypted_data.encrypt(assertion.to_s)
         encrypted_key.set_encryption_method(algorithm:               'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
                                             digest_method_algorithm: 'http://www.w3.org/2000/09/xmldsig#sha1')
+        encrypted_key.key_info = if include_certificate || key_name
+          key_info = Saml::Elements::KeyInfo.new(include_certificate ? certificate.to_pem : nil)
+          key_info.key_name = key_name
+          key_info
+        end
         encrypted_key.encrypt(certificate.public_key)
-
-        key_info = Saml::Elements::KeyInfo.new(certificate.to_pem)
-        key_info.key_name = key_name
-        encrypted_key.key_info = key_info
 
         Saml::Elements::EncryptedAssertion.new(encrypted_data: encrypted_data, encrypted_keys: encrypted_key)
       end

--- a/lib/saml/util.rb
+++ b/lib/saml/util.rb
@@ -80,8 +80,11 @@ module Saml
         encrypted_key = encrypted_data.encrypt(assertion.to_s)
         encrypted_key.set_encryption_method(algorithm:               'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
                                             digest_method_algorithm: 'http://www.w3.org/2000/09/xmldsig#sha1')
-        encrypted_key.set_key_name(key_name)
         encrypted_key.encrypt(certificate.public_key)
+
+        key_info = Saml::Elements::KeyInfo.new(certificate.to_pem)
+        key_info.key_name = key_name
+        encrypted_key.key_info = key_info
 
         Saml::Elements::EncryptedAssertion.new(encrypted_data: encrypted_data, encrypted_keys: encrypted_key)
       end

--- a/spec/lib/saml/util_spec.rb
+++ b/spec/lib/saml/util_spec.rb
@@ -348,6 +348,11 @@ describe Saml::Util do
     context 'with a certificate as param' do
       let(:encrypted_assertion) { Saml::Util.encrypt_assertion(Saml::Assertion.new, service_provider.certificate) }
 
+      it 'adds a key_info w/o key_name to the encrypted assertion' do
+        expect(encrypted_assertion.encrypted_keys.key_info.key_name).to be_nil
+        expect(encrypted_assertion.encrypted_keys.key_info.x509Data.x509certificate).to eq service_provider.certificate
+      end
+
       it 'returns an encrypted assertion object' do
         expect(encrypted_assertion).to be_a Saml::Elements::EncryptedAssertion
       end
@@ -360,10 +365,12 @@ describe Saml::Util do
 
     context 'with a key descriptor as param' do
       let(:key_name) { '22cd8e9f32a7262d2f49f5ccc518ccfbf8441bb8' }
-      let(:encrypted_assertion) { Saml::Util.encrypt_assertion(Saml::Assertion.new, service_provider.find_key_descriptor(key_name)) }
+      let(:key_descriptor) { service_provider.find_key_descriptor(key_name) }
+      let(:encrypted_assertion) { Saml::Util.encrypt_assertion(Saml::Assertion.new, key_descriptor) }
 
-      it 'adds a key_name to the encrypted assertion' do
+      it 'adds a key_info w/ key_name to the encrypted assertion' do
         expect(encrypted_assertion.encrypted_keys.key_info.key_name).to eq key_name
+        expect(encrypted_assertion.encrypted_keys.key_info.x509Data.x509certificate).to eq key_descriptor.certificate
       end
     end
 


### PR DESCRIPTION
Hi, one of my client's SP requires SP certificate in the response's encrypted assertion.
I've added it and updated related specs.

ps.
This change increase the response size a bit.
If you don't like it, I can make the certificate optional.