### PR TITLE
Make AuthnRequest Signature and SigAlg optional

### DIFF
--- a/spec/lib/saml/bindings/http_redirect_spec.rb
+++ b/spec/lib/saml/bindings/http_redirect_spec.rb
@@ -115,6 +115,19 @@ describe Saml::Bindings::HTTPRedirect do
           expect(params["Signature"]).to eq(sha1_signature_mri)
         end
       end
+
+      context "with exclude_signature option" do
+        let(:url) do
+          described_class.create_url(authn_request,
+                                     exclude_signature: true
+          )
+        end
+
+        it "not add Signature and SigAlg params" do
+          expect(params["Signature"]).to eq nil
+          expect(params["SigAlg"]).to eq nil
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Motivation
In my use case, AuthnRequest doesn't need to be signed. 
Our IdP is Azure which said the following:
https://docs.microsoft.com/en-us/azure/active-directory/develop/single-sign-on-saml-protocol#signature

> Signature
Don't include a Signature element in AuthnRequest elements, as Azure AD does not support signed authentication requests.

Besides, by making AuthnRequest optional, when adding service-provider to provider store, we don't need to specify a signing key.

## Relate issues
https://github.com/digidentity/libsaml/issues/168#issuecomment-586922207

## Changes 
- Added instance variable `exclude_signature`, defined by `options[:exclude_signature]`
- Existing applications which are not specifying this option will run as usual (sign AuthnRequest and add Signature, SigAlg params in AuthnRequest URL)
- Will not sign and add Signature, SigAlg params in AuthnRequest URL if specify `exclude_signature = true`

Usage:
```ruby
Saml::Bindings::HTTPRedirect.create_url(authn_request, exclude_signature: true)
```
