### PR TITLE
Encrypt EncryptedID and EncryptedAttribute elements by (re)using the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.9.0
+* Encrypt EncryptedID and EncryptedAttributes elements by (re)using the same #encrypt_element method.
+
 ### 3.8.0
 * Fix encryption of an EncryptedID for multiple KeyDescriptors
 

--- a/lib/saml/elements/encrypted_attribute.rb
+++ b/lib/saml/elements/encrypted_attribute.rb
@@ -15,27 +15,9 @@ module Saml
       validates :encrypted_data, presence: true
 
       def encrypt(attribute, encrypted_key_data, encrypted_data_options = {})
-        self.encrypted_data = Xmlenc::Builder::EncryptedData.new(encrypted_data_options)
-        self.encrypted_data.set_encryption_method algorithm: 'http://www.w3.org/2001/04/xmlenc#aes256-cbc'
-        self.encrypted_data.set_key_name key_name
-
-        encrypted_key_data.each do |key_descriptor, key_options|
-          encrypted_key = self.encrypted_data.encrypt Nokogiri::XML(attribute.to_xml).root.to_xml, key_options
-          encrypted_key.set_encryption_method algorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p', digest_method_algorithm: 'http://www.w3.org/2000/09/xmldsig#sha1'
-          encrypted_key.set_key_name key_descriptor.key_info.key_name
-          encrypted_key.carried_key_name = key_name
-          encrypted_key.encrypt key_descriptor.certificate.public_key
-
-          self.encrypted_keys ||= []
-          self.encrypted_keys << encrypted_key
-        end
+        Saml::Util.encrypt_element(self, attribute, encrypted_key_data, encrypted_data_options)
       end
 
-      private
-
-      def key_name
-        @key_name ||= Saml.generate_id
-      end
     end
   end
 end

--- a/lib/saml/version.rb
+++ b/lib/saml/version.rb
@@ -1,3 +1,3 @@
 module Saml
-  VERSION = '3.8.0'
+  VERSION = '3.9.0'
 end

--- a/spec/lib/saml/elements/encrypted_attribute_spec.rb
+++ b/spec/lib/saml/elements/encrypted_attribute_spec.rb
@@ -63,6 +63,11 @@ describe Saml::Elements::EncryptedAttribute do
 
     let(:encrypt) { subject.encrypt(attribute, encrypted_key_data, encrypted_data_options) }
 
+    it 'calls #encrypt_element' do
+      expect(Saml::Util).to receive(:encrypt_element).with(subject, attribute, encrypted_key_data, encrypted_data_options)
+      encrypt
+    end
+
     it 'builds an encrypted data element' do
       encrypt
       expect(subject.encrypted_data).to be_a Xmlenc::Builder::EncryptedData
@@ -87,15 +92,15 @@ describe Saml::Elements::EncryptedAttribute do
       end
 
       # NOTE The xmlmapper gem will order XML namespaces differently under JRuby and MRI
-      
+
       let(:xml_attribute_jruby) { "<saml:Attribute xmlns:ext=\"urn:oasis:names:tc:SAML:attributes:ext\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\"/>" }
       let(:xml_attribute_mri) { '<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ext="urn:oasis:names:tc:SAML:attributes:ext"/>' }
       it 'encrypts the XML of the passed in attribute' do
         if RUBY_ENGINE == 'jruby'
-          expect_any_instance_of(Xmlenc::Builder::EncryptedData).to receive(:encrypt).with(xml_attribute_jruby, { recipient: 'recipient' }).and_call_original
+          expect_any_instance_of(Xmlenc::Builder::EncryptedData).to receive(:encrypt).with(xml_attribute_jruby, {}).and_call_original
           encrypt
         else
-          expect_any_instance_of(Xmlenc::Builder::EncryptedData).to receive(:encrypt).with(xml_attribute_mri, { recipient: 'recipient' }).and_call_original
+          expect_any_instance_of(Xmlenc::Builder::EncryptedData).to receive(:encrypt).with(xml_attribute_mri, {}).and_call_original
           encrypt
         end
       end


### PR DESCRIPTION
…same #encrypt_element method.

There were major differences between encrypting EncryptedIDs and EncryptedAttributes.


- This also fixes a bug when encrypting EncryptedAttributes with multiple KeyDescriptors ( see #825282 ).

- Adds support for multiple recipient when encrypting EncryptedID’s by passing the recipient per KeyDescriptor as EncryptedKeyData.

- Bump version and update changelog.