### PR TITLE
Add invalid params error handling for `Saml::Bindings::HTTPPost.receive_message`

### DIFF
--- a/lib/saml.rb
+++ b/lib/saml.rb
@@ -34,6 +34,8 @@ module Saml
     end
     class UnparseableMessage < SamlError
     end
+    class InvalidParams < SamlError
+    end
     class MetadataDownloadFailed < SamlError
     end
     class InvalidStore < SamlError

--- a/lib/saml/bindings/http_post.rb
+++ b/lib/saml/bindings/http_post.rb
@@ -20,7 +20,12 @@ module Saml
         end
 
         def receive_message(request, type)
-          message             = Saml::Encoding.decode_64(request.params["SAMLRequest"] || request.params["SAMLResponse"])
+          receive_xml = request.params["SAMLRequest"] || request.params["SAMLResponse"]
+          if receive_xml.nil?
+            raise Saml::Errors::InvalidParams, 'require params `SAMLRequest` or `SAMLResponse`'
+          end
+
+          message             = Saml::Encoding.decode_64(receive_xml)
           notify('receive_message', message)
           request_or_response = Saml.parse_message(message, type)
 

--- a/spec/lib/saml/bindings/http_post_spec.rb
+++ b/spec/lib/saml/bindings/http_post_spec.rb
@@ -69,5 +69,14 @@ describe Saml::Bindings::HTTPPost do
         message
       }.to notify_with('receive_message')
     end
+
+    context 'When both `SAMLRequest` and `SAMLResponse` is nil in request params' do
+      let(:request) { double(:request, params: {}, url: "https://sp.example.com/sso") }
+      let(:message) { described_class.receive_message(request, :response) }
+
+      it 'Raise Saml::Errors::InvalidParams' do
+        expect { message }.to raise_error(Saml::Errors::InvalidParams, 'require params `SAMLRequest` or `SAMLResponse`')
+      end
+    end
   end
 end


### PR DESCRIPTION
Thanks for creating a great gem.
I created this PR because I found one problem while developing a project using this gem. Please check if you like.

## Summary

If both `SAMLRequest` and` SAMLResponse` are nil in the request parameter, the argument `nil` is specified in` Saml::Encoding#decode_64` and the exception `NoMethodError` is raised.

```
$ Saml::Encoding.decode_64(nil)
NoMethodError: undefined method `unpack1' for nil:NilClass
from /usr/local/lib/ruby/2.7.0/base64.rb:59:in `decode64'
```

See: https://github.com/digidentity/libsaml/blob/master/lib/saml/bindings/http_post.rb#L23

This isn't friendly to developers, so I've added an exception class `Saml::Errors::InvalidParams` to detect this.