### PR TITLE
Add SessionNotOnOrAfter attribute to Saml::Elements::AuthnStatement

### DIFF
--- a/lib/saml/assertion.rb
+++ b/lib/saml/assertion.rb
@@ -46,7 +46,8 @@ module Saml
       @authn_statement = Saml::Elements::AuthnStatement.new(authn_instant: authn_instant,
                                                             address: options.delete(:address),
                                                             authn_context_class_ref: options.delete(:authn_context_class_ref),
-                                                            session_index: options.delete(:session_index))
+                                                            session_index: options.delete(:session_index),
+                                                            session_not_on_or_after: options.delete(:session_not_on_or_after))
       super(*(args << options))
       @_id           ||= Saml.generate_id
       @issue_instant ||= Time.now

--- a/lib/saml/elements/authn_statement.rb
+++ b/lib/saml/elements/authn_statement.rb
@@ -8,6 +8,7 @@ module Saml
 
       attribute :authn_instant, Time, tag: "AuthnInstant", on_save: lambda { |val| val.utc.xmlschema }
       attribute :session_index, String, tag: "SessionIndex"
+      attribute :session_not_on_or_after, Time, tag: "SessionNotOnOrAfter", on_save: lambda { |val| val.utc.xmlschema if val.present?}
 
       has_one :subject_locality, Saml::Elements::SubjectLocality, tag: "SubjectLocality"
       has_one :authn_context, Saml::Elements::AuthnContext, tag: "AuthnContext"

--- a/spec/fixtures/artifact_response.xml
+++ b/spec/fixtures/artifact_response.xml
@@ -43,7 +43,7 @@
           </saml:Conditions>
           <saml:Statement>
           </saml:Statement>
-          <saml:AuthnStatement AuthnInstant="2011-08-31T08:51:05Z" SessionIndex="_93af655219464fb403b34436cfb0c5cb1d9a5502">
+          <saml:AuthnStatement AuthnInstant="2011-08-31T08:51:05Z" SessionIndex="_93af655219464fb403b34436cfb0c5cb1d9a5502" SessionNotOnOrAfter="2011-09-01T08:51:05Z">
             <saml:AuthnContext>
               <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
             </saml:AuthnContext>
@@ -83,7 +83,7 @@
       </saml:Advice>
       <saml:Statement>
       </saml:Statement>
-      <saml:AuthnStatement AuthnInstant="2011-08-31T08:51:05Z" SessionIndex="_93af655219464fb403b34436cfb0c5cb1d9a5502">
+      <saml:AuthnStatement AuthnInstant="2011-08-31T08:51:05Z" SessionIndex="_93af655219464fb403b34436cfb0c5cb1d9a5502" SessionNotOnOrAfter="2011-09-01T08:51:05Z">
         <saml:AuthnContext>
           <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
         </saml:AuthnContext>

--- a/spec/lib/saml/assertion_spec.rb
+++ b/spec/lib/saml/assertion_spec.rb
@@ -114,6 +114,7 @@ describe Saml::Assertion do
     it 'parses AuthnStatement elements' do
       aggregate_failures do
         expect(assertion.authn_statement.size).to eq 1
+        expect(assertion.authn_statement.first.session_not_on_or_after).to eq(Time.parse("2011-09-01T08:51:05Z"))
         expect(assertion.authn_statement.first).to be_a(Saml::Elements::AuthnStatement)
       end
     end


### PR DESCRIPTION
## What
Add `SessionNotOnOrAfter` attribute to `Saml::Elements::AuthnStatement`.

## Why
From SAML core spec [2.7.2](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf):

> SessionNotOnOrAfter [Optional]
>
> Specifies a time instant at which the session between the principal identified by the subject and the SAML authority issuing this statement MUST be considered ended. The time value is encoded in UTC, as described in Section 1.3.3.

This solve #172 