### PR TITLE
Feature/include key retrieval method

### DIFF
--- a/lib/saml/response.rb
+++ b/lib/saml/response.rb
@@ -28,10 +28,14 @@ module Saml
       !success? && status.status_code.unknown_principal?
     end
 
-    def encrypt_assertions(certificate, include_certificate: false)
+    def encrypt_assertions(key_descriptor_or_certificate, include_certificate: false, include_key_retrieval_method: false)
       @encrypted_assertions = []
       assertions.each do |assertion|
-        @encrypted_assertions << Saml::Util.encrypt_assertion(assertion, certificate, include_certificate: include_certificate)
+        @encrypted_assertions << Saml::Util.encrypt_assertion(
+          assertion, key_descriptor_or_certificate,
+          include_certificate: include_certificate,
+          include_key_retrieval_method: include_key_retrieval_method
+        )
       end
       assertions.clear
     end

--- a/lib/saml/util.rb
+++ b/lib/saml/util.rb
@@ -60,7 +60,7 @@ module Saml
         end
       end
 
-      def encrypt_assertion(assertion, key_descriptor_or_certificate, include_certificate: false)
+      def encrypt_assertion(assertion, key_descriptor_or_certificate, include_certificate: false, include_key_retrieval_method: false)
         case key_descriptor_or_certificate
         when OpenSSL::X509::Certificate
           certificate = key_descriptor_or_certificate
@@ -75,6 +75,9 @@ module Saml
         assertion = assertion.to_xml(nil, nil, false) if assertion.is_a?(Assertion) # create xml without instruct
 
         encrypted_data = Xmlenc::Builder::EncryptedData.new
+        if include_key_retrieval_method && key_name
+          encrypted_data.set_key_retrieval_method (Xmlenc::Builder::RetrievalMethod.new(uri: "##{key_name}"))
+        end
         encrypted_data.set_encryption_method(algorithm: 'http://www.w3.org/2001/04/xmlenc#aes128-cbc')
 
         encrypted_key = encrypted_data.encrypt(assertion.to_s)

--- a/spec/lib/saml/util_spec.rb
+++ b/spec/lib/saml/util_spec.rb
@@ -371,6 +371,16 @@ describe Saml::Util do
           expect(encrypted_assertion.encrypted_keys.key_info.x509Data.x509certificate.to_pem).to eq service_provider.certificate.to_pem
         end
       end
+
+      context 'with include_key_retrieval_method option' do
+        let(:encrypted_assertion) do
+          Saml::Util.encrypt_assertion(Saml::Assertion.new, service_provider.certificate, include_key_retrieval_method: true)
+        end
+
+        it 'ignores the option' do
+          expect(encrypted_assertion.encrypted_data.key_info).to be_nil
+        end
+      end
     end
 
     context 'with a key descriptor as param' do
@@ -391,6 +401,17 @@ describe Saml::Util do
         it 'adds a key_info w/ x509Data w/ key_name to the encrypted assertion' do
           expect(encrypted_assertion.encrypted_keys.key_info.key_name).to eq key_name
           expect(encrypted_assertion.encrypted_keys.key_info.x509Data.x509certificate.to_pem).to eq service_provider.certificate.to_pem
+        end
+      end
+
+      context 'with include_key_retrieval_method option' do
+        let(:encrypted_assertion) do
+          Saml::Util.encrypt_assertion(Saml::Assertion.new, key_descriptor, include_key_retrieval_method: true)
+        end
+
+        it 'add key_retrieval_method' do
+          expect(encrypted_assertion.encrypted_keys.key_info.key_name).to eq key_name
+          expect(encrypted_assertion.encrypted_data.key_info.retrieval_method.uri).to eq "##{key_name}"
         end
       end
     end

--- a/spec/lib/saml/util_spec.rb
+++ b/spec/lib/saml/util_spec.rb
@@ -377,8 +377,9 @@ describe Saml::Util do
           Saml::Util.encrypt_assertion(Saml::Assertion.new, service_provider.certificate, include_key_retrieval_method: true)
         end
 
-        it 'ignores the option' do
-          expect(encrypted_assertion.encrypted_data.key_info).to be_nil
+        it 'add key_retrieval_method' do
+          expect(encrypted_assertion.encrypted_keys.id).not_to be_nil
+          expect(encrypted_assertion.encrypted_data.key_info.retrieval_method.uri).to eq "##{encrypted_assertion.encrypted_keys.id}"
         end
       end
     end
@@ -410,8 +411,8 @@ describe Saml::Util do
         end
 
         it 'add key_retrieval_method' do
-          expect(encrypted_assertion.encrypted_keys.key_info.key_name).to eq key_name
-          expect(encrypted_assertion.encrypted_data.key_info.retrieval_method.uri).to eq "##{key_name}"
+          expect(encrypted_assertion.encrypted_keys.id).not_to be_nil
+          expect(encrypted_assertion.encrypted_data.key_info.retrieval_method.uri).to eq "##{encrypted_assertion.encrypted_keys.id}"
         end
       end
     end


### PR DESCRIPTION
add "include_key_retrieval_method" option

on those methods
* Saml::Response#encrypt_assertions
* Saml::Util#encrypt_assertion

ref.) https://github.com/digidentity/libsaml/issues/151

NOTE: I've changed referencing via `key_name` to referencing via `encrypted_key.id`.