### PR TITLE
Add invalid params error handling for `Saml::Bindings::HTTPRedirect.receive_message`

### DIFF
--- a/lib/saml/bindings/http_redirect.rb
+++ b/lib/saml/bindings/http_redirect.rb
@@ -14,6 +14,11 @@ module Saml
           options[:signature_algorithm] = http_request.params["SigAlg"]
           options[:relay_state]         = http_request.params["RelayState"]
 
+          receive_xml = http_request.params["SAMLRequest"] || http_request.params["SAMLResponse"]
+          if receive_xml.nil?
+            raise Saml::Errors::InvalidParams, 'require params `SAMLRequest` or `SAMLResponse`'
+          end
+          
           request_or_response = parse_request_or_response(options.delete(:type), http_request.params)
 
           redirect_binding = new(request_or_response, options)

--- a/spec/lib/saml/bindings/http_redirect_spec.rb
+++ b/spec/lib/saml/bindings/http_redirect_spec.rb
@@ -190,5 +190,13 @@ describe Saml::Bindings::HTTPRedirect do
         end
       end
     end
+
+    context 'When both `SAMLRequest` and `SAMLResponse` is nil in request params' do
+      let(:request) { double(:request, params: {}, url: url) }
+
+      it 'Raise Saml::Errors::InvalidParams' do
+        expect{ described_class.receive_message(request, type: :authn_request) }.to raise_error(Saml::Errors::InvalidParams, 'require params `SAMLRequest` or `SAMLResponse`')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
`Saml::Bindings::HTTPRedirect.receive_message` decodes the request parameter` SAMLRequest` or `SAMLResponse`, but if neither exists, it becomes` nil`. Then, `nil` is specified in the argument of Saml :: Encoding.decode_64` method, and the following error occurs.

```
$ Saml::Encoding.decode_64(nil)
NoMethodError: undefined method `unpack1' for nil:NilClass
from /usr/local/lib/ruby/2.7.0/base64.rb:59:in `decode64'
```

This error isn't kind to the developer, so I've added a process to check that the input parameter has a `SAMLRequest` or` SAMLResponse` and raise an exception if it doesn't.

This is similar to the next PR. https://github.com/digidentity/libsaml/pull/176