### PR TITLE
Added support for SHA512

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test, :development do
   gem 'simplecov'
   gem 'factory_bot_rails'
   gem 'rspec-collection_matchers', '~> 1.0'
+  gem 'rexml'
 end
 
 # Declare any dependencies that are still in development here instead of in

--- a/lib/saml/provider.rb
+++ b/lib/saml/provider.rb
@@ -105,6 +105,8 @@ module Saml
     def digest_method(signature_algorithm)
       digest = signature_algorithm && signature_algorithm =~ /sha(.*?)$/i && $1.to_i
       case digest
+        when 512 then
+          OpenSSL::Digest::SHA512
         when 256 then
           OpenSSL::Digest::SHA256
         else

--- a/spec/lib/saml/provider_spec.rb
+++ b/spec/lib/saml/provider_spec.rb
@@ -204,12 +204,24 @@ describe Saml::Provider do
   end
 
   describe "#sign" do
-    it "uses the encryption key to sign" do
-      expect(service_provider.sign("sha256", "test")).to eq(service_provider.encryption_key.sign(OpenSSL::Digest::SHA256.new, "test"))
+    context "using sha256" do
+      it "uses the encryption key to sign" do
+        expect(service_provider.sign("sha256", "test")).to eq(service_provider.encryption_key.sign(OpenSSL::Digest::SHA256.new, "test"))
+      end
+
+      it "uses the signing key to sign if present" do
+        expect(service_provider_with_signing_key.sign("sha256", "test")).to eq(service_provider_with_signing_key.signing_key.sign(OpenSSL::Digest::SHA256.new, "test"))
+      end
     end
 
-    it "uses the signing key to sign if present" do
-      expect(service_provider_with_signing_key.sign("sha256", "test")).to eq(service_provider_with_signing_key.signing_key.sign(OpenSSL::Digest::SHA256.new, "test"))
+    context "using sha512" do
+      it "uses the encryption key to sign" do
+        expect(service_provider.sign("sha512", "test")).to eq(service_provider.encryption_key.sign(OpenSSL::Digest::SHA512.new, "test"))
+      end
+
+      it "uses the signing key to sign if present" do
+        expect(service_provider_with_signing_key.sign("sha512", "test")).to eq(service_provider_with_signing_key.signing_key.sign(OpenSSL::Digest::SHA512.new, "test"))
+      end
     end
   end
 


### PR DESCRIPTION
SHA512 signed SAML requests were causing invalid signature errors. 