### PR TITLE
skip_signature option on Saml::Bindings::HTTPPost#create_form_attributes

### DIFF
--- a/lib/saml/bindings/http_post.rb
+++ b/lib/saml/bindings/http_post.rb
@@ -7,7 +7,12 @@ module Saml
         def create_form_attributes(message, options = {})
           param = message.is_a?(Saml::ComplexTypes::StatusResponseType) ? "SAMLResponse" : "SAMLRequest"
 
-          xml = notify('create_message', Saml::Util.sign_xml(message))
+          xml = if options[:skip_signature]
+            message.to_xml
+          else
+            Saml::Util.sign_xml(message)
+          end
+          notify('create_message', xml)
 
           variables        = {}
           variables[param] = Saml::Encoding.encode_64(xml)

--- a/spec/lib/saml/bindings/http_post_spec.rb
+++ b/spec/lib/saml/bindings/http_post_spec.rb
@@ -34,6 +34,22 @@ describe Saml::Bindings::HTTPPost do
     it 'creates a notification' do
       expect { form_attributes }.to notify_with('create_message')
     end
+
+    context 'when skip_signature option given' do
+      let(:form_attributes) do
+        described_class.create_form_attributes(
+          response,
+          relay_state: "relay_state",
+          skip_signature: true
+        )
+      end
+
+      it "does not sign the document" do
+        encoded_response = form_attributes[:variables]["SAMLResponse"]
+        response         = Saml::Response.parse(Saml::Encoding.decode_64(encoded_response))
+        expect(response.signature).not_to be_present
+      end
+    end
   end
 
   describe ".receive_message" do


### PR DESCRIPTION
some SP want assertions signed, and responses not signed.
(eg. OBC Bugyou Cloud, one of the biggest accounting SaaS software in Japan)