### PR TITLE
Make `rexml` a required gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ group :test, :development do
   gem 'simplecov'
   gem 'factory_bot_rails'
   gem 'rspec-collection_matchers', '~> 1.0'
-  gem 'rexml'
 end
 
 # Declare any dependencies that are still in development here instead of in

--- a/saml.gemspec
+++ b/saml.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemodel', '>= 4.2'
   s.add_dependency 'xmlmapper', '~> 0.8.1'
   s.add_dependency 'nokogiri', '~> 1.11'
+  s.add_dependency 'rexml'
   s.add_dependency 'xmldsig', '>= 0.5.1', '< 0.8.0'
   s.add_dependency 'xmlenc', '>= 0.6.9', '< 0.9.0'
 


### PR DESCRIPTION
Ruby 3.0 removed `rexml` from the default gems.
As libsaml expects `REXML::ParseException` to be present, `rexml` is required to make the gem work.

https://github.com/digidentity/libsaml/blob/538ba3a067ae5ece16221f06d2f265993daec257/lib/saml/base.rb#L56